### PR TITLE
Fix __PHP_Incomplete_Class when not logged in

### DIFF
--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -210,6 +210,11 @@ class ParseUser extends ParseObject
     }
     $storage = ParseClient::getStorage();
     $userData = $storage->get("user");
+    
+    // fix __PHP_Incomplete_Class
+    if (!is_object($userData))
+      $userData = unserialize(serialize($userData));
+      
     if ($userData instanceof ParseUser) {
       static::$currentUser = $userData;
       return $userData;


### PR DESCRIPTION
When no user is logged in and I want to run any query what so ever I receive a fatal error of $userData being and __PHP_Incomplete_Class object.

When an user is logged in I no longer have this problem. The proposed code fixes this when the object is broken only.