### PR TITLE
Making ParseUser and ParseRole subclassable

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -77,8 +77,14 @@ final class ParseClient
      */
     public static function initialize($app_id, $rest_key, $master_key, $enableCurlExceptions = true)
     {
-        ParseUser::registerSubclass();
-        ParseRole::registerSubclass();
+        if (! ParseObject::hasRegisteredSubclass('_User')) {
+            ParseUser::registerSubclass();
+        }
+
+        if (! ParseObject::hasRegisteredSubclass('_Role')) {
+            ParseRole::registerSubclass();
+        }
+
         ParseInstallation::registerSubclass();
         ParseSession::registerSubclass();
         self::$applicationId = $app_id;

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1225,6 +1225,35 @@ class ParseObject implements Encodable
     }
 
     /**
+     * Check whether there is a subclass registered for a given parse class
+     *
+     * @param $parseClassName
+     *
+     * @return bool
+     */
+    public static function hasRegisteredSubclass($parseClassName)
+    {
+        return array_key_exists($parseClassName, self::$registeredSubclasses);
+    }
+
+    /**
+     * Get the registered subclass for a Parse class, or a generic ParseObject
+     * if no subclass is registered.
+     *
+     * @param $parseClassName
+     *
+     * @return ParseObject
+     */
+    public static function getRegisteredSubclass($parseClassName)
+    {
+        if (self::hasRegisteredSubclass($parseClassName)) {
+            return self::$registeredSubclasses[$parseClassName];
+        }
+
+        return new static($parseClassName);
+    }
+
+    /**
      * Creates a ParseQuery for the subclass of ParseObject.
      * Cannot be called on the base class ParseObject.
      *

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -16,7 +16,7 @@ class ParseUser extends ParseObject
      *
      * @var ParseUser
      */
-    private static $currentUser = null;
+    protected static $currentUser = null;
 
     /**
      * The sessionToken for an authenticated user.
@@ -137,7 +137,7 @@ class ParseUser extends ParseObject
         }
         $data = ["username" => $username, "password" => $password];
         $result = ParseClient::_request("GET", "/1/login", "", $data);
-        $user = new ParseUser();
+        $user = new static();
         $user->_mergeAfterFetch($result);
         $user->handleSaveResult(true);
         ParseClient::getStorage()->set("user", $user);
@@ -156,7 +156,7 @@ class ParseUser extends ParseObject
     public static function become($sessionToken)
     {
         $result = ParseClient::_request('GET', '/1/users/me', $sessionToken);
-        $user = new ParseUser();
+        $user = new static();
         $user->_mergeAfterFetch($result);
         $user->handleSaveResult(true);
         ParseClient::getStorage()->set("user", $user);
@@ -173,7 +173,7 @@ class ParseUser extends ParseObject
      */
     public static function logOut()
     {
-        $user = ParseUser::getCurrentUser();
+        $user = static::getCurrentUser();
         if ($user) {
             try {
                 ParseClient::_request('POST', '/1/logout', $user->getSessionToken());
@@ -192,7 +192,7 @@ class ParseUser extends ParseObject
      *
      * @return null
      */
-    private function handleSaveResult($makeCurrent = false)
+    protected function handleSaveResult($makeCurrent = false)
     {
         if (isset($this->serverData['password'])) {
             unset($this->serverData['password']);
@@ -227,7 +227,7 @@ class ParseUser extends ParseObject
             return $userData;
         }
         if (isset($userData["id"]) && isset($userData["_sessionToken"])) {
-            $user = ParseUser::create("_User", $userData["id"]);
+            $user = static::create("_User", $userData["id"]);
             unset($userData["id"]);
             $user->_sessionToken = $userData["_sessionToken"];
             unset($userData["_sessionToken"]);
@@ -251,7 +251,7 @@ class ParseUser extends ParseObject
     protected static function saveCurrentUser()
     {
         $storage = ParseClient::getStorage();
-        $storage->set('user', ParseUser::getCurrentUser());
+        $storage->set('user', static::getCurrentUser());
     }
 
     /**
@@ -271,8 +271,8 @@ class ParseUser extends ParseObject
      */
     public function isCurrent()
     {
-        if (ParseUser::getCurrentUser() && $this->getObjectId()) {
-            if ($this->getObjectId() == ParseUser::getCurrentUser()->getObjectId()) {
+        if (static::getCurrentUser() && $this->getObjectId()) {
+            if ($this->getObjectId() == static::getCurrentUser()->getObjectId()) {
                 return true;
             }
         }


### PR DESCRIPTION
This makes a few adjustments to make `ParseUser` and `ParseRole` subclassable.

Most of the changes are pretty self-explanitory, however a note about the `ParseObject::getRegisteredSubclass()` method: This is very useful to be able to dynamically retrieve the correct registered subclass for a given Parse class. I'm using this method in my Laravel integration package to provide authentication drivers, among other things.

This PR addresses #42.

Thanks!