### PR TITLE
minor fix

### DIFF
--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -315,7 +315,7 @@ class ParseUser extends ParseObject
             foreach ($userData as $key => $value) {
                 $user->set($key, $value);
             }
-            $user->_opSetQueue = [];
+            $user->setArray("_opSetQueue", []);
             static::$currentUser = $user;
 
             return $user;


### PR DESCRIPTION
ParseObject do not support setting array value to property by using setter.