### PR TITLE
`ParseObject::fetch` should return `$this`

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -507,7 +507,7 @@ class ParseObject implements Encodable
      *
      * @param bool $useMasterKey Whether to use the master key and override ACLs
      *
-     * @return null
+     * @return ParseObject Returns self, so you can chain this call.
      */
     public function fetch($useMasterKey = false)
     {
@@ -521,6 +521,8 @@ class ParseObject implements Encodable
             $sessionToken, null, $useMasterKey
         );
         $this->_mergeAfterFetch($response);
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
For easy chaining, have you considered returning $this from ParseObject::fetch?

    public function fetch($useMasterKey = false)
    {
        $sessionToken = null;
        if (ParseUser::getCurrentUser()) {
            $sessionToken = ParseUser::getCurrentUser()->getSessionToken();
        }
        $response = ParseClient::_request(
            'GET',
            '/1/classes/'.$this->className.'/'.$this->objectId,
            $sessionToken, null, $useMasterKey
        );
        $this->_mergeAfterFetch($response);
        
        return $this;
    }

    $name = (new ParseObject("Animal", "ObFp5S29xm"))->fetch()->name