### PR TITLE
validate api url construction

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -255,7 +255,7 @@ final class ParseClient
         self::assertParseInitialized();
         $headers = self::_getRequestHeaders($sessionToken, $useMasterKey);
 
-        $url = self::HOST_NAME.$relativeUrl;
+        $url = self::HOST_NAME . '/' . ltrim($relativeUrl, '/');
         if ($method === 'GET' && !empty($data)) {
             $url .= '?'.http_build_query($data);
         }


### PR DESCRIPTION
This is only one check that must be done all around the library.
As mostly everything is publicly accessible you don't really know who will call _request, or what parameters will be provided
You are assuming no-one will call "_" methods because they are supposed to be private?