### PR TITLE
API version constant, remove from _request calls

### DIFF
--- a/src/Parse/ParseAnalytics.php
+++ b/src/Parse/ParseAnalytics.php
@@ -56,7 +56,7 @@ class ParseAnalytics
 
         return ParseClient::_request(
             'POST',
-            '/1/events/'.$name,
+            'events/' . $name,
             null,
             static::_toSaveJSON($dimensions)
         );

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -391,7 +391,7 @@ final class ParseClient
      */
     public static function getAPIUrl()
     {
-        return self::HOST_NAME . '/' . self::API_VERSION;
+        return self::HOST_NAME . '/' . self::API_VERSION . '/';
     }
 
     /**

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -17,6 +17,11 @@ final class ParseClient
     const HOST_NAME = 'https://api.parse.com';
 
     /**
+     * Constant for the API Service version.
+     */
+    const API_VERSION = '1';
+
+    /**
      * The application id.
      *
      * @var string
@@ -255,7 +260,7 @@ final class ParseClient
         self::assertParseInitialized();
         $headers = self::_getRequestHeaders($sessionToken, $useMasterKey);
 
-        $url = self::HOST_NAME . '/' . ltrim($relativeUrl, '/');
+        $url = self::HOST_NAME . '/' . self::API_VERSION . '/' . ltrim($relativeUrl, '/');
         if ($method === 'GET' && !empty($data)) {
             $url .= '?'.http_build_query($data);
         }
@@ -377,6 +382,16 @@ final class ParseClient
         $headers[] = 'Expect: ';
 
         return $headers;
+    }
+
+    /**
+     * Get remote Parse API url.
+     *
+     * @return string
+     */
+    public static function getAPIUrl()
+    {
+        return self::HOST_NAME . '/' . self::API_VERSION;
     }
 
     /**

--- a/src/Parse/ParseCloud.php
+++ b/src/Parse/ParseCloud.php
@@ -26,7 +26,7 @@ class ParseCloud
         }
         $response = ParseClient::_request(
             'POST',
-            '/1/functions/'.$name,
+            'functions/' . $name,
             $sessionToken,
             json_encode(ParseClient::_encode($data, null, false)),
             $useMasterKey

--- a/src/Parse/ParseConfig.php
+++ b/src/Parse/ParseConfig.php
@@ -16,7 +16,7 @@ class ParseConfig
      */
     public function __construct()
     {
-        $result = ParseClient::_request("GET", "/1/config");
+        $result = ParseClient::_request('GET', 'config');
         $this->setConfig($result['params']);
     }
 

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -90,7 +90,7 @@ class ParseFile implements \Parse\Internal\Encodable
         }
 
         $headers = ParseClient::_getRequestHeaders(null, true);
-        $url = ParseClient::getAPIUrl() . '/files/' . $this->getName();
+        $url = ParseClient::getAPIUrl() . 'files/' . $this->getName();
         $rest = curl_init();
         curl_setopt($rest, CURLOPT_URL, $url);
         curl_setopt($rest, CURLOPT_CUSTOMREQUEST, "DELETE");
@@ -206,7 +206,7 @@ class ParseFile implements \Parse\Internal\Encodable
         $mimeType = $this->mimeType ?: $this->getMimeTypeForExtension($extension);
 
         $headers = ParseClient::_getRequestHeaders(null, false);
-        $url = ParseClient::getAPIUrl . '/files/' . $this->getName();
+        $url = ParseClient::getAPIUrl() . 'files/' . $this->getName();
         $rest = curl_init();
         curl_setopt($rest, CURLOPT_URL, $url);
         curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -90,7 +90,7 @@ class ParseFile implements \Parse\Internal\Encodable
         }
 
         $headers = ParseClient::_getRequestHeaders(null, true);
-        $url = ParseClient::HOST_NAME.'/1/files/'.$this->getName();
+        $url = ParseClient::getAPIUrl() . '/files/' . $this->getName();
         $rest = curl_init();
         curl_setopt($rest, CURLOPT_URL, $url);
         curl_setopt($rest, CURLOPT_CUSTOMREQUEST, "DELETE");
@@ -206,7 +206,7 @@ class ParseFile implements \Parse\Internal\Encodable
         $mimeType = $this->mimeType ?: $this->getMimeTypeForExtension($extension);
 
         $headers = ParseClient::_getRequestHeaders(null, false);
-        $url = ParseClient::HOST_NAME.'/1/files/'.$this->getName();
+        $url = ParseClient::getAPIUrl . '/files/' . $this->getName();
         $rest = curl_init();
         curl_setopt($rest, CURLOPT_URL, $url);
         curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -517,11 +517,11 @@ class ParseObject implements Encodable
         }
         $response = ParseClient::_request(
             'GET',
-            '/1/classes/'.$this->className.'/'.$this->objectId,
+            'classes/' . $this->className . '/' . $this->objectId,
             $sessionToken, null, $useMasterKey
         );
         $this->_mergeAfterFetch($response);
-        
+
         return $this;
     }
 
@@ -751,8 +751,11 @@ class ParseObject implements Encodable
             $sessionToken = ParseUser::getCurrentUser()->getSessionToken();
         }
         ParseClient::_request(
-            'DELETE', '/1/classes/'.$this->className.
-            '/'.$this->objectId, $sessionToken, null, $useMasterKey
+            'DELETE',
+            'classes/' . $this->className . '/' . $this->objectId,
+            $sessionToken,
+            null,
+            $useMasterKey
         );
     }
 
@@ -802,9 +805,9 @@ class ParseObject implements Encodable
         $errors = [];
         foreach ($objects as $object) {
             $data[] = [
-                "method" => "DELETE",
-                "path"   => "/1/classes/".$object->getClassName().
-                    "/".$object->getObjectId(),
+                "method" => 'DELETE',
+                "path"   => 'classes/' . $object->getClassName().
+                    '/' . $object->getObjectId(),
             ];
         }
         $sessionToken = null;
@@ -812,7 +815,7 @@ class ParseObject implements Encodable
             $sessionToken = ParseUser::getCurrentUser()->getSessionToken();
         }
         $result = ParseClient::_request(
-            "POST", "/1/batch", $sessionToken,
+            'POST', 'batch', $sessionToken,
             json_encode(["requests" => $data]),
             $useMasterKey
         );
@@ -1018,7 +1021,7 @@ class ParseObject implements Encodable
             foreach ($batch as $obj) {
                 $json = $obj->getSaveJSON();
                 $method = 'POST';
-                $path = '/1/classes/'.$obj->getClassName();
+                $path = 'classes/' . $obj->getClassName();
                 if ($obj->getObjectId()) {
                     $path .= '/'.$obj->getObjectId();
                     $method = 'PUT';
@@ -1038,7 +1041,7 @@ class ParseObject implements Encodable
                 $batch[0]->mergeAfterSave($result);
             } else {
                 $result = ParseClient::_request(
-                    'POST', '/1/batch', $sessionToken,
+                    'POST', 'batch', $sessionToken,
                     json_encode(["requests" => $requests]), $useMasterKey
                 );
 

--- a/src/Parse/ParsePush.php
+++ b/src/Parse/ParsePush.php
@@ -59,7 +59,7 @@ class ParsePush
 
         return ParseClient::_request(
             'POST',
-            '/1/push',
+            'push',
             null,
             json_encode($data),
             $useMasterKey

--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -318,8 +318,10 @@ class ParseQuery
         $queryString = $this->buildQueryString($this->_getOptions());
         $result = ParseClient::_request(
             'GET',
-            '/1/classes/'.$this->className.
-            '?'.$queryString, $sessionToken, null, $useMasterKey
+            'classes/' . $this->className . '?' . $queryString,
+            $sessionToken,
+            null,
+            $useMasterKey
         );
 
         return $result['count'];
@@ -341,8 +343,10 @@ class ParseQuery
         $queryString = $this->buildQueryString($this->_getOptions());
         $result = ParseClient::_request(
             'GET',
-            '/1/classes/'.$this->className.
-            '?'.$queryString, $sessionToken, null, $useMasterKey
+            'classes/' . $this->className . '?' . $queryString,
+            $sessionToken,
+            null,
+            $useMasterKey
         );
         $output = [];
         foreach ($result['results'] as $row) {

--- a/src/Parse/ParseSession.php
+++ b/src/Parse/ParseSession.php
@@ -33,7 +33,13 @@ class ParseSession extends ParseObject
     public static function getCurrentSession($useMasterKey = false)
     {
         $token = ParseUser::getCurrentUser()->getSessionToken();
-        $response = ParseClient::_request('GET', '/1/sessions/me', $token, null, $useMasterKey);
+        $response = ParseClient::_request(
+            'GET',
+            'sessions/me',
+            $token,
+            null,
+            $useMasterKey
+        );
         $session = new ParseSession();
         $session->_mergeAfterFetch($response);
         $session->handleSaveResult();

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -136,7 +136,7 @@ class ParseUser extends ParseObject
             );
         }
         $data = ["username" => $username, "password" => $password];
-        $result = ParseClient::_request("GET", "/1/login", "", $data);
+        $result = ParseClient::_request('GET', 'login', '', $data);
         $user = new static();
         $user->_mergeAfterFetch($result);
         $user->handleSaveResult(true);
@@ -176,7 +176,7 @@ class ParseUser extends ParseObject
                 "expiration_date" => ParseClient::getProperDateFormat($expiration_date)
             ]
         ]];
-        $result = ParseClient::_request("POST", "/1/users", "", json_encode($data));
+        $result = ParseClient::_request('POST', 'users', '', json_encode($data));
         $user = ParseObject::create('_User');
         $user->_mergeAfterFetch($result);
         $user->handleSaveResult(true);
@@ -204,7 +204,7 @@ class ParseUser extends ParseObject
             ]
         ]];
 
-        $result = ParseClient::_request("POST", "/1/users", "", json_encode($data));
+        $result = ParseClient::_request('POST', 'users', '', json_encode($data));
         $user = new ParseUser();
         $user->_mergeAfterFetch($result);
         $user->handleSaveResult(true);
@@ -246,7 +246,7 @@ class ParseUser extends ParseObject
             ]
         ]];
         $result = ParseClient::_request(
-            "PUT", "/1/users/" . $this->getObjectId(),
+            'PUT', 'users/' . $this->getObjectId(),
             $this->getSessionToken(), json_encode($data), $useMasterKey
         );
         $user = new ParseUser();
@@ -265,7 +265,7 @@ class ParseUser extends ParseObject
      */
     public static function become($sessionToken)
     {
-        $result = ParseClient::_request('GET', '/1/users/me', $sessionToken);
+        $result = ParseClient::_request('GET', 'users/me', $sessionToken);
         $user = new static();
         $user->_mergeAfterFetch($result);
         $user->handleSaveResult(true);
@@ -277,7 +277,7 @@ class ParseUser extends ParseObject
     /**
      * Log out the current user.    This will clear the storage and future calls
      *     to current will return null.
-     * This will make a network request to /1/logout to invalidate the session.
+     * This will make a network request to logout to invalidate the session.
      *
      * @return null
      */
@@ -286,7 +286,7 @@ class ParseUser extends ParseObject
         $user = static::getCurrentUser();
         if ($user) {
             try {
-                ParseClient::_request('POST', '/1/logout', $user->getSessionToken());
+                ParseClient::_request('POST', 'logout', $user->getSessionToken());
             } catch (ParseException $ex) {
                 // If this fails, we're going to ignore it.
             }
@@ -420,7 +420,7 @@ class ParseUser extends ParseObject
     public static function requestPasswordReset($email)
     {
         $json = json_encode(['email' => $email]);
-        ParseClient::_request('POST', '/1/requestPasswordReset', null, $json);
+        ParseClient::_request('POST', 'requestPasswordReset', null, $json);
     }
 
     public static function _clearCurrentUserVariable()


### PR DESCRIPTION
As commented on ticket #146 API version `/1/` is all around the library.
With this PR it is defined as a constant on ParseClient and used to compose _request calls to Parse API Service