### PR TITLE
Support empty query

### DIFF
--- a/src/Parse/ParsePush.php
+++ b/src/Parse/ParsePush.php
@@ -41,7 +41,15 @@ class ParsePush
         }
         if (isset($data['where'])) {
             if ($data['where'] instanceof ParseQuery) {
-                $data['where'] = $data['where']->_getOptions()['where'];
+                
+                $where_options   = $data['where']->_getOptions();
+
+                if (!isset($query_where['where'])) {
+                    $data['where'] = '{}';
+                } else {
+                    $data['where'] = $data['where']->_getOptions()['where'];
+                }
+
             } else {
                 throw new Exception(
                     'Where parameter for Parse Push must be of type ParseQuery'


### PR DESCRIPTION
Parse pusher supports pushing to all installations at once using "where" : "{}", however with php sdk it's not possible, if you don't pass a where query it will throw "'Missing the push channels.", if an empty ParseQuery is used, "undefined index where" is thrown. This patch aim to pass a "{}" if an empty parse query object is passed.