### PR TITLE
Increasing User class test coverage and correcting batch operations

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -645,6 +645,11 @@ class ParseObject implements Encodable
         }
     }
 
+    /**
+     * Merge data from other object
+     *
+     * @param ParseObject $other
+     */
     private function mergeFromObject($other)
     {
         if (!$other) {
@@ -780,6 +785,16 @@ class ParseObject implements Encodable
         return;
     }
 
+    /**
+     * Destroy batch of objects
+     *
+     * @param ParseObject[] $objects
+     * @param bool $useMasterKey
+     *
+     * @return array
+     *
+     * @throws ParseException
+     */
     private static function destroyBatch(array $objects, $useMasterKey = false)
     {
         $data = [];
@@ -1013,6 +1028,9 @@ class ParseObject implements Encodable
                 );
                 $batch[0]->mergeAfterSave($result);
             } else {
+                foreach ($requests as &$r){
+                    $r['path'] = '/1/' . $r['path'];
+                }
                 $result = ParseClient::_request(
                     'POST',
                     'batch',

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -802,7 +802,7 @@ class ParseObject implements Encodable
         foreach ($objects as $object) {
             $data[] = [
                 'method' => 'DELETE',
-                'path' => 'classes/'.$object->getClassName().'/'.$object->getObjectId(),
+                'path'   => 'classes/'.$object->getClassName().'/'.$object->getObjectId(),
             ];
         }
         $sessionToken = null;
@@ -823,7 +823,7 @@ class ParseObject implements Encodable
                     $result[$key]['error']['code'] : -1;
                 $errors[] = [
                     'error' => $error,
-                    'code' => $code,
+                    'code'  => $code,
                 ];
             }
         }
@@ -1012,8 +1012,8 @@ class ParseObject implements Encodable
                     $method = 'PUT';
                 }
                 $requests[] = ['method' => $method,
-                    'path' => $path,
-                    'body' => $json,
+                    'path'              => $path,
+                    'body'              => $json,
                 ];
             }
 
@@ -1050,14 +1050,14 @@ class ParseObject implements Encodable
                         $code = isset($response['error']['code']) ?
                             $response['error']['code'] : -1;
                         $errorCollection[] = [
-                            'error' => $error,
-                            'code' => $code,
+                            'error'  => $error,
+                            'code'   => $code,
                             'object' => $obj,
                         ];
                     } else {
                         $errorCollection[] = [
-                            'error' => 'Unknown error in batch save.',
-                            'code' => -1,
+                            'error'  => 'Unknown error in batch save.',
+                            'code'   => -1,
                             'object' => $obj,
                         ];
                     }
@@ -1233,9 +1233,9 @@ class ParseObject implements Encodable
         }
 
         return [
-                '__type' => 'Pointer',
+                '__type'    => 'Pointer',
                 'className' => $this->className,
-                'objectId' => $this->objectId, ];
+                'objectId'  => $this->objectId, ];
     }
 
     /**

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -646,7 +646,7 @@ class ParseObject implements Encodable
     }
 
     /**
-     * Merge data from other object
+     * Merge data from other object.
      *
      * @param ParseObject $other
      */
@@ -786,14 +786,14 @@ class ParseObject implements Encodable
     }
 
     /**
-     * Destroy batch of objects
+     * Destroy batch of objects.
      *
      * @param ParseObject[] $objects
-     * @param bool $useMasterKey
-     *
-     * @return array
+     * @param bool          $useMasterKey
      *
      * @throws ParseException
+     *
+     * @return array
      */
     private static function destroyBatch(array $objects, $useMasterKey = false)
     {
@@ -802,7 +802,7 @@ class ParseObject implements Encodable
         foreach ($objects as $object) {
             $data[] = [
                 'method' => 'DELETE',
-                'path'   => 'classes/'.$object->getClassName().'/'.$object->getObjectId(),
+                'path' => 'classes/'.$object->getClassName().'/'.$object->getObjectId(),
             ];
         }
         $sessionToken = null;
@@ -823,7 +823,7 @@ class ParseObject implements Encodable
                     $result[$key]['error']['code'] : -1;
                 $errors[] = [
                     'error' => $error,
-                    'code'  => $code,
+                    'code' => $code,
                 ];
             }
         }
@@ -1012,8 +1012,8 @@ class ParseObject implements Encodable
                     $method = 'PUT';
                 }
                 $requests[] = ['method' => $method,
-                    'path'              => $path,
-                    'body'              => $json,
+                    'path' => $path,
+                    'body' => $json,
                 ];
             }
 
@@ -1028,8 +1028,8 @@ class ParseObject implements Encodable
                 );
                 $batch[0]->mergeAfterSave($result);
             } else {
-                foreach ($requests as &$r){
-                    $r['path'] = '/1/' . $r['path'];
+                foreach ($requests as &$r) {
+                    $r['path'] = '/1/'.$r['path'];
                 }
                 $result = ParseClient::_request(
                     'POST',
@@ -1050,14 +1050,14 @@ class ParseObject implements Encodable
                         $code = isset($response['error']['code']) ?
                             $response['error']['code'] : -1;
                         $errorCollection[] = [
-                            'error'  => $error,
-                            'code'   => $code,
+                            'error' => $error,
+                            'code' => $code,
                             'object' => $obj,
                         ];
                     } else {
                         $errorCollection[] = [
-                            'error'  => 'Unknown error in batch save.',
-                            'code'   => -1,
+                            'error' => 'Unknown error in batch save.',
+                            'code' => -1,
                             'object' => $obj,
                         ];
                     }
@@ -1233,9 +1233,9 @@ class ParseObject implements Encodable
         }
 
         return [
-                '__type'    => 'Pointer',
+                '__type' => 'Pointer',
                 'className' => $this->className,
-                'objectId'  => $this->objectId, ];
+                'objectId' => $this->objectId, ];
     }
 
     /**

--- a/tests/Parse/ParseUserTest.php
+++ b/tests/Parse/ParseUserTest.php
@@ -26,6 +26,16 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
         ParseUser::_unregisterSubclass();
     }
 
+    public function testUserAttributes()
+    {
+        $user = new ParseUser();
+        $user->setUsername('asdf');
+        $user->setPassword('zxcv');
+        $user->setEmail('asds@mail.com');
+        $this->assertEquals('asdf', $user->getUsername());
+        $this->assertEquals('asds@mail.com', $user->getEmail());
+    }
+
     public function testUserSignUp()
     {
         $user = new ParseUser();
@@ -41,6 +51,18 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
         $user = ParseUser::logIn('asdf', 'zxcv');
         $this->assertTrue($user->isAuthenticated());
         $this->assertEquals('asdf', $user->get('username'));
+    }
+
+    public function testLoginEmptyUsername()
+    {
+        $this->setExpectedException('Parse\ParseException', 'empty name');
+        $user = ParseUser::logIn('', 'bogus');
+    }
+
+    public function testLoginEmptyPassword()
+    {
+        $this->setExpectedException('Parse\ParseException', 'empty password');
+        $user = ParseUser::logIn('asdf', '');
     }
 
     public function testLoginWrongUsername()
@@ -72,6 +94,15 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('Parse\ParseException', 'invalid session');
         $failUser = ParseUser::become('garbage_token');
+    }
+
+    public function testCannotSingUpAlreadyExistingUser()
+    {
+        $this->testUserSignUp();
+        $user = ParseUser::getCurrentUser();
+        $user->setPassword('zxcv');
+        $this->setExpectedException('Parse\ParseException', 'already existing user');
+        $user->signUp();
     }
 
     public function testCannotAlterOtherUser()
@@ -338,8 +369,8 @@ class ParseUserTest extends \PHPUnit_Framework_TestCase
         $user->destroy();
 
         $query = ParseUser::query();
-        $this->setExpectedException('Parse\ParseException', 'Object not found');
-        $fail = $query->get($user->getObjectId());
+        $this->setExpectedException('Parse\ParseException', 'Object not found.');
+        $fail = $query->get($user->getObjectId(), true);
     }
 
     public function testCountUsers()


### PR DESCRIPTION
In batch processing to the **path** of each object was missing "/1/" as in the [rest guide](https://parse.com/docs/rest/guide#objects-batch-operations).

```
curl -X POST \
  -H "X-Parse-Application-Id: plOyifDWSSvahk0z2qJkF3ZWUZLf5zZiQZ5z7u7R" \
  -H "X-Parse-REST-API-Key: EpYFDWfBspYlclm3X0Puqaa73JWM64eAOPib4iL2" \
  -H "Content-Type: application/json" \
  -d '{
        "requests": [
          {
            "method": "POST",
            "path": "/1/classes/GameScore",
            "body": {
              "score": 1337,
              "playerName": "Sean Plott"
            }
          },
          {
            "method": "POST",
            "path": "/1/classes/GameScore",
            "body": {
              "score": 1338,
              "playerName": "ZeroCool"
            }
          }
        ]
      }' \
  https://api.parse.com/1/batch
```

But now with the fix was inserted "/1/" for each batch processing object with the following [code](https://github.com/phelipealves/parse-php-sdk/blob/0df3213f3a8fe2dfbf39d94f337b14850b2a6bd1/src/Parse/ParseObject.php#L1031-1033):
```
foreach ($requests as &$r) {
       $r['path'] = '/1/'.$r['path'];
}
```

When you run a batch process for the request:
```
{
    "requests": [
        {
            "method": "PUT",
            "path": "classes/TestObject/q07p9cDga3",
            "body": {
                "num": 1
            }
        },
        {
            "method": "POST",
            "path": "classes/TestObject",
            "body": {
                "num": 2
            }
        },
        {
            "method": "PUT",
            "path": "classes/_User/rO4PAwfNe5",
            "body": {
                "username": "changed"
            }
        }
    ]
}
```

The answer was:
```
{"code":107,"error":"Method 'PUT' to classes/TestObject/' not supported in batch operations."}
or
{"code":107,"error":"Method 'POST' to classes/TestObject/' not supported in batch operations."}
```

And adding /1/ in the path:
```
{
    "requests": [
        {
            "method": "PUT",
            "path": "/1/classes/TestObject/q07p9cDga3",
            "body": {
                "num": 1
            }
        },
        {
            "method": "POST",
            "path": "/1/classes/TestObject",
            "body": {
                "num": 2
            }
        },
        {
            "method": "PUT",
            "path": "/1/classes/_User/rO4PAwfNe5",
            "body": {
                "username": "changed"
            }
        }
    ]
}
```

The correct result:
```
[
    {
        "success": {
            "updatedAt": "2015-10-30T16:37:50.127Z"
        }
    },
    {
        "success": {
            "createdAt": "2015-10-30T16:37:50.127Z",
            "objectId": "N27nSliCbQ"
        }
    },
    {
        "error": {
            "code": 206,
            "error": "Parse::UserCannotBeAlteredWithoutSessionError"
        }
    }
]
```


