### PR TITLE
Fix serialization of unindexed arrays

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -318,7 +318,7 @@ class ParseObject implements Encodable
                 'Must use set() for non-array values.'
             );
         }
-        $this->_performOperation($key, new SetOperation($value));
+        $this->_performOperation($key, new SetOperation(array_values($value)));
     }
 
     /**

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -638,6 +638,16 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSetArray()
+    {
+        $arr = [0 => 'foo', 2 => 'bar'];
+        $obj = ParseObject::create('TestObject');
+        $obj->setArray('arr', $arr);
+        $obj->save();
+
+        $this->assertEquals($obj->get('arr'), array_values($arr));
+    }
+
     public function testAddUnique()
     {
         $obj = ParseObject::create('TestObject');


### PR DESCRIPTION
If we try to save an object with an unindexed array, a ParseException is thrown : 

`Parse\ParseException: invalid type for key arr, expected array, but got map`

This is due to `json_encode` as 

```php
$coll = [
    0 => 'foo',
    2 => 'bar'
];
```
will be encoded to : 
```json
{
	"0": "foo",
	"2": "bar"
}
```
instead of 
```json
["foo", "bar"]
```

This PR force reindexation of the arrays passed to setArray with `array_values`