### PR TITLE
Replace cURL calls by Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": ">=5.4.0",
         "ext-curl": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^5|^6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "ext-curl": "*",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^5|^6"
+        "guzzlehttp/guzzle": "~5.0|~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -92,7 +92,7 @@ final class ParseClient
     /**
      * Guzzle client.
      *
-     * @var \GuzzleHttp\Client
+     * @var \GuzzleHttp\ClientInterface
      */
     private static $client;
 

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -106,12 +106,12 @@ final class ParseClient
     /**
      * Parse\Client::initialize, must be called before using Parse features.
      *
-     * @param string          $app_id               Parse Application ID
-     * @param string          $rest_key             Parse REST API Key
-     * @param string          $master_key           Parse Master Key
-     * @param bool            $enableCurlExceptions Enable or disable Parse curl exceptions
-     * @param string          $account_key          Parse Account Key
-     * @param ClientInterface $client               Guzzle client
+     * @param string               $app_id               Parse Application ID
+     * @param string               $rest_key             Parse REST API Key
+     * @param string               $master_key           Parse Master Key
+     * @param bool                 $enableCurlExceptions Enable or disable Parse curl exceptions
+     * @param string               $account_key          Parse Account Key
+     * @param ClientInterface|null $client               Guzzle client
      *
      * @throws Exception
      */
@@ -142,7 +142,7 @@ final class ParseClient
                 self::setStorage(new ParseMemoryStorage());
             }
         }
-        self::$client = (null !== $client) ? $client : new Client();
+        self::$client = $client ?: new Client();
     }
 
     /**

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -339,6 +339,7 @@ final class ParseClient
             if (self::$enableCurlExceptions) {
                 throw self::handleGuzzleException($e);
             }
+
             return false;
         }
 
@@ -361,6 +362,7 @@ final class ParseClient
      * Wrap Guzzle Exception in a ParseException.
      *
      * @param ClientException $e
+     *
      * @return ParseException
      */
     public static function handleGuzzleException(ClientException $e)
@@ -374,6 +376,7 @@ final class ParseClient
                 $message = $decoded->error;
             }
         }
+
         return new ParseException($message, $code, $e);
     }
 

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -106,12 +106,12 @@ final class ParseClient
     /**
      * Parse\Client::initialize, must be called before using Parse features.
      *
-     * @param string           $app_id               Parse Application ID
-     * @param string           $rest_key             Parse REST API Key
-     * @param string           $master_key           Parse Master Key
-     * @param bool             $enableCurlExceptions Enable or disable Parse curl exceptions
-     * @param string           $account_key          Parse Account Key
-     * @param ClientInterface  $client               Guzzle client
+     * @param string          $app_id               Parse Application ID
+     * @param string          $rest_key             Parse REST API Key
+     * @param string          $master_key           Parse Master Key
+     * @param bool            $enableCurlExceptions Enable or disable Parse curl exceptions
+     * @param string          $account_key          Parse Account Key
+     * @param ClientInterface $client               Guzzle client
      *
      * @throws Exception
      */
@@ -158,7 +158,7 @@ final class ParseClient
     /**
      * Returns enableCurlExceptions.
      *
-     * @return boolean
+     * @return bool
      */
     public static function getEnableCurlExceptions()
     {

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -5,6 +5,8 @@ namespace Parse;
 use Exception;
 use InvalidArgumentException;
 use Parse\Internal\Encodable;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 
 /**
  * ParseClient - Main class for Parse initialization and communication.
@@ -87,6 +89,13 @@ final class ParseClient
     private static $timeout;
 
     /**
+     * Guzzle client
+     *
+     * @var \GuzzleHttp\Client
+     */
+    private static $client;
+
+    /**
      * Constant for version string to include with requests.
      *
      * @var string
@@ -100,12 +109,12 @@ final class ParseClient
      * @param string $rest_key             Parse REST API Key
      * @param string $master_key           Parse Master Key
      * @param bool   $enableCurlExceptions Enable or disable Parse curl exceptions
-     * @param null   $email                Parse Account Email
-     * @param null   $password             Parse Account Password
+     * @param string $account_key          Parse Account Key
+     * @param array  $guzzleConfig         Constructor argument for GuzzleHttp\Client
      *
      * @throws Exception
      */
-    public static function initialize($app_id, $rest_key, $master_key, $enableCurlExceptions = true, $account_key = null)
+    public static function initialize($app_id, $rest_key, $master_key, $enableCurlExceptions = true, $account_key = null, $guzzleConfig = [])
     {
         if (!ParseObject::hasRegisteredSubclass('_User')) {
             ParseUser::registerSubclass();
@@ -132,6 +141,17 @@ final class ParseClient
                 self::setStorage(new ParseMemoryStorage());
             }
         }
+        self::$client = new Client($guzzleConfig);
+    }
+
+    /**
+     * Returns GuzzleClient.
+     *
+     * @return \GuzzleHttp\Client
+     */
+    public static function getClient()
+    {
+        return self::$client;
     }
 
     /**
@@ -301,47 +321,32 @@ final class ParseClient
         if ($method === 'GET' && !empty($data)) {
             $url .= '?'.http_build_query($data);
         }
-        $rest = curl_init();
-        curl_setopt($rest, CURLOPT_URL, $url);
-        curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);
-        if ($method === 'POST') {
-            $headers[] = 'Content-Type: application/json';
-            curl_setopt($rest, CURLOPT_POST, 1);
-            curl_setopt($rest, CURLOPT_POSTFIELDS, $data);
-        }
-        if ($method === 'PUT') {
-            $headers[] = 'Content-Type: application/json';
-            curl_setopt($rest, CURLOPT_CUSTOMREQUEST, $method);
-            curl_setopt($rest, CURLOPT_POSTFIELDS, $data);
-        }
-        if ($method === 'DELETE') {
-            curl_setopt($rest, CURLOPT_CUSTOMREQUEST, $method);
-        }
-        curl_setopt($rest, CURLOPT_HTTPHEADER, $headers);
 
-        if (!is_null(self::$connectionTimeout)) {
-            curl_setopt($rest, CURLOPT_CONNECTTIMEOUT, self::$connectionTimeout);
-        }
-        if (!is_null(self::$timeout)) {
-            curl_setopt($rest, CURLOPT_TIMEOUT, self::$timeout);
+        $options = [
+            'headers' => $headers,
+            'connect_timeout' => !is_null(self::$connectionTimeout) ? self::$connectionTimeout : 0,
+            'timeout' => !is_null(self::$timeout) ? self::$timeout : 0,
+        ];
+
+        if ($method === 'POST' || $method === 'PUT') {
+            $options['headers']['Content-Type'] = 'json';
+            $options['body'] = $data;
         }
 
-        $response = curl_exec($rest);
-        $status = curl_getinfo($rest, CURLINFO_HTTP_CODE);
-        $contentType = curl_getinfo($rest, CURLINFO_CONTENT_TYPE);
-        if (curl_errno($rest)) {
+        try {
+            $response = self::$client->request($method, $url, $options);
+        } catch (ClientException $e) {
             if (self::$enableCurlExceptions) {
-                throw new ParseException(curl_error($rest), curl_errno($rest));
-            } else {
-                return false;
+                throw self::handleGuzzleException($e);
             }
+            return false;
         }
-        curl_close($rest);
-        if (strpos($contentType, 'text/html') !== false) {
+
+        if (strpos($response->getHeader('Content-Type')[0], 'text/html') !== false) {
             throw new ParseException('Bad Request', -1);
         }
 
-        $decoded = json_decode($response, true);
+        $decoded = json_decode($response->getBody(), true);
         if (isset($decoded['error'])) {
             throw new ParseException(
                 $decoded['error'],
@@ -350,6 +355,26 @@ final class ParseClient
         }
 
         return $decoded;
+    }
+
+    /**
+     * Wrap Guzzle Exception in a ParseException.
+     *
+     * @param  ClientException $e
+     * @return ParseException
+     */
+    public static function handleGuzzleException(ClientException $e)
+    {
+        $code = $e->getCode();
+        $message = $e->getMessage();
+        if ($e->hasResponse()) {
+            $decoded = json_decode($e->getResponse()->getBody());
+            if ($decoded !== false && property_exists($decoded, 'code') && property_exists($decoded, 'error')) {
+                $code = $decoded->code;
+                $message = $decoded->error;
+            }
+        }
+        return new ParseException($message, $code, $e);
     }
 
     /**
@@ -414,25 +439,27 @@ final class ParseClient
      */
     public static function _getRequestHeaders($sessionToken, $useMasterKey)
     {
-        $headers = ['X-Parse-Application-Id: '.self::$applicationId,
-            'X-Parse-Client-Version: '.self::VERSION_STRING, ];
+        $headers = [
+            'X-Parse-Application-Id' => self::$applicationId,
+            'X-Parse-Client-Version' => self::VERSION_STRING
+        ];
         if ($sessionToken) {
-            $headers[] = 'X-Parse-Session-Token: '.$sessionToken;
+            $headers['X-Parse-Session-Token'] = $sessionToken;
         }
         if ($useMasterKey) {
-            $headers[] = 'X-Parse-Master-Key: '.self::$masterKey;
+            $headers['X-Parse-Master-Key'] = self::$masterKey;
         } else {
-            $headers[] = 'X-Parse-REST-API-Key: '.self::$restKey;
+            $headers['X-Parse-REST-API-Key'] = self::$restKey;
         }
         if (self::$forceRevocableSession) {
-            $headers[] = 'X-Parse-Revocable-Session: 1';
+            $headers['X-Parse-Revocable-Session'] = '1';
         }
         /*
          * Set an empty Expect header to stop the 100-continue behavior for post
          *     data greater than 1024 bytes.
          *     http://pilif.github.io/2007/02/the-return-of-except-100-continue/
          */
-        $headers[] = 'Expect: ';
+        $headers['Expect'] = '';
 
         return $headers;
     }
@@ -445,7 +472,7 @@ final class ParseClient
         if (is_null(self::$accountKey) || empty(self::$accountKey)) {
             throw new InvalidArgumentException('A account key is required and can not be null or empty');
         } else {
-            $headers[] = 'X-Parse-Account-Key: '.self::$accountKey;
+            $headers['X-Parse-Account-Key'] = self::$accountKey;
         }
 
         /*
@@ -453,7 +480,7 @@ final class ParseClient
          *     data greater than 1024 bytes.
          *     http://pilif.github.io/2007/02/the-return-of-except-100-continue/
          */
-        $headers[] = 'Expect: ';
+        $headers['Expect'] = '';
 
         return $headers;
     }

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -3,10 +3,10 @@
 namespace Parse;
 
 use Exception;
-use InvalidArgumentException;
-use Parse\Internal\Encodable;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use InvalidArgumentException;
+use Parse\Internal\Encodable;
 
 /**
  * ParseClient - Main class for Parse initialization and communication.
@@ -89,7 +89,7 @@ final class ParseClient
     private static $timeout;
 
     /**
-     * Guzzle client
+     * Guzzle client.
      *
      * @var \GuzzleHttp\Client
      */
@@ -323,9 +323,9 @@ final class ParseClient
         }
 
         $options = [
-            'headers' => $headers,
+            'headers'         => $headers,
             'connect_timeout' => !is_null(self::$connectionTimeout) ? self::$connectionTimeout : 0,
-            'timeout' => !is_null(self::$timeout) ? self::$timeout : 0,
+            'timeout'         => !is_null(self::$timeout) ? self::$timeout : 0,
         ];
 
         if ($method === 'POST' || $method === 'PUT') {
@@ -360,7 +360,7 @@ final class ParseClient
     /**
      * Wrap Guzzle Exception in a ParseException.
      *
-     * @param  ClientException $e
+     * @param ClientException $e
      * @return ParseException
      */
     public static function handleGuzzleException(ClientException $e)
@@ -441,7 +441,7 @@ final class ParseClient
     {
         $headers = [
             'X-Parse-Application-Id' => self::$applicationId,
-            'X-Parse-Client-Version' => self::VERSION_STRING
+            'X-Parse-Client-Version' => self::VERSION_STRING,
         ];
         if ($sessionToken) {
             $headers['X-Parse-Session-Token'] = $sessionToken;

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -4,6 +4,7 @@ namespace Parse;
 
 use Exception;
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use InvalidArgumentException;
 use Parse\Internal\Encodable;
@@ -105,16 +106,16 @@ final class ParseClient
     /**
      * Parse\Client::initialize, must be called before using Parse features.
      *
-     * @param string $app_id               Parse Application ID
-     * @param string $rest_key             Parse REST API Key
-     * @param string $master_key           Parse Master Key
-     * @param bool   $enableCurlExceptions Enable or disable Parse curl exceptions
-     * @param string $account_key          Parse Account Key
-     * @param array  $guzzleConfig         Constructor argument for GuzzleHttp\Client
+     * @param string           $app_id               Parse Application ID
+     * @param string           $rest_key             Parse REST API Key
+     * @param string           $master_key           Parse Master Key
+     * @param bool             $enableCurlExceptions Enable or disable Parse curl exceptions
+     * @param string           $account_key          Parse Account Key
+     * @param ClientInterface  $client               Guzzle client
      *
      * @throws Exception
      */
-    public static function initialize($app_id, $rest_key, $master_key, $enableCurlExceptions = true, $account_key = null, $guzzleConfig = [])
+    public static function initialize($app_id, $rest_key, $master_key, $enableCurlExceptions = true, $account_key = null, ClientInterface $client = null)
     {
         if (!ParseObject::hasRegisteredSubclass('_User')) {
             ParseUser::registerSubclass();
@@ -141,7 +142,7 @@ final class ParseClient
                 self::setStorage(new ParseMemoryStorage());
             }
         }
-        self::$client = new Client($guzzleConfig);
+        self::$client = (null !== $client) ? $client : new Client();
     }
 
     /**
@@ -152,6 +153,16 @@ final class ParseClient
     public static function getClient()
     {
         return self::$client;
+    }
+
+    /**
+     * Returns enableCurlExceptions.
+     *
+     * @return boolean
+     */
+    public static function getEnableCurlExceptions()
+    {
+        return self::$enableCurlExceptions;
     }
 
     /**

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -2,8 +2,8 @@
 
 namespace Parse;
 
-use Parse\Internal\Encodable;
 use GuzzleHttp\Exception\ClientException;
+use Parse\Internal\Encodable;
 
 /**
  * ParseFile - Representation of a Parse File object.
@@ -100,6 +100,7 @@ class ParseFile implements Encodable
             if (ParseClient::$enableCurlExceptions) {
                 throw ParseClient::handleGuzzleException($e);
             }
+
             return false;
         }
     }
@@ -217,6 +218,7 @@ class ParseFile implements Encodable
             if (ParseClient::$enableCurlExceptions) {
                 throw ParseClient::handleGuzzleException($e);
             }
+
             return false;
         }
 
@@ -243,6 +245,7 @@ class ParseFile implements Encodable
             if (ParseClient::$enableCurlExceptions) {
                 throw ParseClient::handleGuzzleException($e);
             }
+
             return false;
         }
 

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -3,6 +3,7 @@
 namespace Parse;
 
 use Parse\Internal\Encodable;
+use GuzzleHttp\Exception\ClientException;
 
 /**
  * ParseFile - Representation of a Parse File object.
@@ -93,17 +94,14 @@ class ParseFile implements Encodable
 
         $headers = ParseClient::_getRequestHeaders(null, true);
         $url = ParseClient::getAPIUrl().'files/'.$this->getName();
-        $rest = curl_init();
-        curl_setopt($rest, CURLOPT_URL, $url);
-        curl_setopt($rest, CURLOPT_CUSTOMREQUEST, 'DELETE');
-        curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($rest, CURLOPT_HTTPHEADER, $headers);
-        $response = curl_exec($rest);
-        $contentType = curl_getinfo($rest, CURLINFO_CONTENT_TYPE);
-        if (curl_errno($rest)) {
-            throw new ParseException(curl_error($rest), curl_errno($rest));
+        try {
+            $response = ParseClient::getClient()->request('DELETE', $url, ['headers' => $headers]);
+        } catch (ClientException $e) {
+            if (ParseClient::$enableCurlExceptions) {
+                throw ParseClient::handleGuzzleException($e);
+            }
+            return false;
         }
-        curl_close($rest);
     }
 
     /**
@@ -208,26 +206,25 @@ class ParseFile implements Encodable
         $mimeType = $this->mimeType ?: $this->getMimeTypeForExtension($extension);
 
         $headers = ParseClient::_getRequestHeaders(null, false);
+        $headers['Content-Type'] = $mimeType;
+
         $url = ParseClient::getAPIUrl().'files/'.$this->getName();
-        $rest = curl_init();
-        curl_setopt($rest, CURLOPT_URL, $url);
-        curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($rest, CURLOPT_BINARYTRANSFER, 1);
-        $headers[] = 'Content-Type: '.$mimeType;
-        curl_setopt($rest, CURLOPT_POST, 1);
-        curl_setopt($rest, CURLOPT_POSTFIELDS, $this->getData());
-        curl_setopt($rest, CURLOPT_HTTPHEADER, $headers);
-        $response = curl_exec($rest);
-        $contentType = curl_getinfo($rest, CURLINFO_CONTENT_TYPE);
-        if (curl_errno($rest)) {
-            throw new ParseException(curl_error($rest), curl_errno($rest));
+        $options = ['headers' => $headers, 'body' => $this->getData()];
+
+        try {
+            $response = ParseClient::getClient()->request('POST', $url, $options);
+        } catch (ClientException $e) {
+            if (ParseClient::$enableCurlExceptions) {
+                throw ParseClient::handleGuzzleException($e);
+            }
+            return false;
         }
-        curl_close($rest);
-        if (strpos($contentType, 'text/html') !== false) {
+
+        if (strpos($response->getHeader('Content-Type')[0], 'text/html') !== false) {
             throw new ParseException('Bad Request', -1);
         }
 
-        $decoded = json_decode($response, true);
+        $decoded = json_decode($response->getBody(), true);
         if (isset($decoded['error'])) {
             throw new ParseException(
                 $decoded['error'],
@@ -240,23 +237,23 @@ class ParseFile implements Encodable
 
     private function download()
     {
-        $rest = curl_init();
-        curl_setopt($rest, CURLOPT_URL, $this->url);
-        curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($rest, CURLOPT_BINARYTRANSFER, 1);
-        $response = curl_exec($rest);
-        if (curl_errno($rest)) {
-            throw new ParseException(curl_error($rest), curl_errno($rest));
+        try {
+            $response = ParseClient::getClient()->request('GET', $this->url);
+        } catch (ClientException $e) {
+            if (ParseClient::$enableCurlExceptions) {
+                throw ParseClient::handleGuzzleException($e);
+            }
+            return false;
         }
-        $httpStatus = curl_getinfo($rest, CURLINFO_HTTP_CODE);
-        if ($httpStatus > 399) {
-            throw new ParseException('Download failed, file may have been deleted.', $httpStatus);
-        }
-        $this->mimeType = curl_getinfo($rest, CURLINFO_CONTENT_TYPE);
-        $this->data = $response;
-        curl_close($rest);
 
-        return $response;
+        if ($response->getStatusCode() != 200) {
+            throw new ParseException('Download failed, file may have been deleted.', $response->getStatusCode());
+        }
+
+        $this->mimeType = $response->getHeader('Content-Type')[0];
+        $this->data = $response->getBody();
+
+        return $this->data;
     }
 
     private function getMimeTypeForExtension($extension)

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -97,7 +97,7 @@ class ParseFile implements Encodable
         try {
             $response = ParseClient::getClient()->request('DELETE', $url, ['headers' => $headers]);
         } catch (ClientException $e) {
-            if (ParseClient::$enableCurlExceptions) {
+            if (ParseClient::getEnableCurlExceptions()) {
                 throw ParseClient::handleGuzzleException($e);
             }
 
@@ -215,7 +215,7 @@ class ParseFile implements Encodable
         try {
             $response = ParseClient::getClient()->request('POST', $url, $options);
         } catch (ClientException $e) {
-            if (ParseClient::$enableCurlExceptions) {
+            if (ParseClient::getEnableCurlExceptions()) {
                 throw ParseClient::handleGuzzleException($e);
             }
 
@@ -242,7 +242,7 @@ class ParseFile implements Encodable
         try {
             $response = ParseClient::getClient()->request('GET', $this->url);
         } catch (ClientException $e) {
-            if (ParseClient::$enableCurlExceptions) {
+            if (ParseClient::getEnableCurlExceptions()) {
                 throw ParseClient::handleGuzzleException($e);
             }
 

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -24,7 +24,7 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
         $file = ParseFile::_createFromServer('hi.txt', 'http://');
         $file2 = ParseFile::createFromData('hello', 'hi.txt');
         $file3 = ParseFile::createFromFile(
-            'ParseFileTest.php',
+            __FILE__,
             'file.php'
         );
         $this->assertEquals('http://', $file->getURL());


### PR DESCRIPTION
As mentionned in #59 , here is an implementation of Guzzle to make HTTP requests instead of cURL.

In term of execution time, I have not noticed a significal improvement, Guzzle use cURL by default after all.

The 6th argument in ParseClient::initialize() gives the possibility to pass options to Guzzle Client, so that custom Handlers and Middleware can be used.

A few tests are failing (like some involving batch actions) but they fail too with the old implementation so I don't know if they are broken or if my test environnement is not well configured.