### PR TITLE
Add getAllKeys method for ParseObject

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -212,6 +212,26 @@ class ParseObject implements Encodable
     }
 
     /**
+     * Get current value for all object properties.
+     *
+     * @return array
+     */
+    public function getAllKeys()
+    {
+		$tempArray = array();
+		
+        foreach(array_keys($this->dataAvailability) as $key) {
+			
+			if (isset($this->estimatedData[$key])) {
+				
+				$tempArray[$key] = $this->estimatedData[$key];
+			}
+		}
+		
+		return $tempArray;
+    }
+
+    /**
      * Check if the object has a given key.
      *
      * @param string $key Key to check

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -218,7 +218,7 @@ class ParseObject implements Encodable
      */
     public function getAllKeys()
     {
-		return isset($this->estimatedData);
+		return $this->estimatedData;
     }
 
     /**

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -218,17 +218,7 @@ class ParseObject implements Encodable
      */
     public function getAllKeys()
     {
-		$tempArray = array();
-		
-        foreach(array_keys($this->dataAvailability) as $key) {
-			
-			if (isset($this->estimatedData[$key])) {
-				
-				$tempArray[$key] = $this->estimatedData[$key];
-			}
-		}
-		
-		return $tempArray;
+		return $this->estimatedData;
     }
 
     /**

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -218,7 +218,7 @@ class ParseObject implements Encodable
      */
     public function getAllKeys()
     {
-		return $this->estimatedData;
+		return isset($this->estimatedData);
     }
 
     /**


### PR DESCRIPTION
Returns all keys for a given object without requiring key name. Similar to the iOS SDK method.