### PR TITLE
Fix DestroyAll return error

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -812,7 +812,7 @@ class ParseObject implements Encodable
         foreach ($objects as $object) {
             $data[] = [
                 'method' => 'DELETE',
-                'path'   => 'classes/'.$object->getClassName().'/'.$object->getObjectId(),
+                'path'   => '/1/classes/'.$object->getClassName().'/'.$object->getObjectId(),
             ];
         }
         $sessionToken = null;


### PR DESCRIPTION
DestroyAll return exception: method 'DELETE' is not supported in batch operation