### PR TITLE
Check whether 'objects' field is empty for relation op

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ After including the required files from the SDK, you need to initalize the Parse
 
 ```php
 ParseClient::initialize( $app_id, $rest_key, $master_key );
-// Users of Parse Server will need to point ParseClient at their remote URL:
-ParseClient::setServerURL('https://my-parse-server.com/parse');
+// Users of Parse Server will need to point ParseClient at their remote URL and Mount Point:
+ParseClient::setServerURL('https://my-parse-server.com','parse');
 ```
 
 Usage

--- a/src/Parse/Internal/ParseRelationOperation.php
+++ b/src/Parse/Internal/ParseRelationOperation.php
@@ -244,14 +244,14 @@ class ParseRelationOperation implements FieldOperation
                 ),
             ];
         }
-        if (!empty($addRelation) && !empty($removeRelation)) {
+        if (!empty($addRelation['objects']) && !empty($removeRelation['objects'])) {
             return [
                 '__op' => 'Batch',
                 'ops'  => [$addRelation, $removeRelation],
             ];
         }
 
-        return empty($addRelation) ? $removeRelation : $addRelation;
+        return empty($addRelation['objects']) ? $removeRelation : $addRelation;
     }
 
     public function _getTargetClass()

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -21,6 +21,13 @@ final class ParseClient
     private static $serverURL = 'https://api.parse.com/1';
 
     /**
+     * The mount path for the current parse server
+     *
+     * @var string
+     */
+    private static $mountPath = "";
+
+    /**
      * The application id.
      *
      * @var string
@@ -131,18 +138,23 @@ final class ParseClient
     }
 
     /**
-     * ParseClient::setServerURL, to change the Parse Server address for this app
-     *
-     * @param string $serverURL The remote server and mount path
+     * ParseClient::setServerURL, to change the Parse Server address & mount path for this app
+     * @param string $serverUrl     The remote server url
+     * @param string $mountPath     The mount path for this server
      *
      * @throws \Exception
+     *
      */
-    public static function setServerURL($serverURL)
-    {
+    public static function setServerURL($serverURL, $mountPath) {
         if (!$serverURL) {
             throw new Exception('Invalid Server URL.');
         }
-        self::$serverURL = $serverURL;
+        if( !$mountPath) {
+            throw new Exception('Invalid Mount Path');
+        }
+
+        self::$serverURL = rtrim($serverURL,'/');
+        self::$mountPath = trim($mountPath,'/') . '/';
     }
 
     /**
@@ -308,7 +320,7 @@ final class ParseClient
             $headers = self::_getRequestHeaders($sessionToken, $useMasterKey);
         }
 
-        $url = self::$serverURL.'/'.ltrim($relativeUrl, '/');
+        $url = self::$serverURL.'/'.self::$mountPath.ltrim($relativeUrl, '/');
         if ($method === 'GET' && !empty($data)) {
             $url .= '?'.http_build_query($data);
         }
@@ -476,7 +488,17 @@ final class ParseClient
      */
     public static function getAPIUrl()
     {
-        return self::$serverURL.'/';
+        return self::$serverURL.'/'.self::$mountPath;
+    }
+
+    /**
+     * Get remote Parse API mount path
+     *
+     * @return string
+     */
+    public static function getMountPath()
+    {
+        return self::$mountPath;
     }
 
     /**

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -150,7 +150,7 @@ final class ParseClient
             throw new Exception('Invalid Server URL.');
         }
         if( !$mountPath) {
-            throw new Exception('Invalid Mount Path');
+            throw new Exception('Invalid Mount Path.');
         }
 
         self::$serverURL = rtrim($serverURL,'/');

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -18,14 +18,14 @@ final class ParseClient
      *
      * @var string
      */
-    private static $serverURL = 'https://api.parse.com/1';
+    private static $serverURL = 'https://api.parse.com/';
 
     /**
      * The mount path for the current parse server
      *
      * @var string
      */
-    private static $mountPath = "";
+    private static $mountPath = "1/";
 
     /**
      * The application id.

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1038,9 +1038,6 @@ class ParseObject implements Encodable
                 );
                 $batch[0]->mergeAfterSave($result);
             } else {
-                foreach ($requests as &$r) {
-                    $r['path'] = $r['path'];
-                }
                 $result = ParseClient::_request(
                     'POST',
                     'batch',

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1039,7 +1039,7 @@ class ParseObject implements Encodable
                 $batch[0]->mergeAfterSave($result);
             } else {
                 foreach ($requests as &$r) {
-                    $r['path'] = '/1/'.$r['path'];
+                    $r['path'] = $r['path'];
                 }
                 $result = ParseClient::_request(
                     'POST',

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -812,7 +812,6 @@ class ParseObject implements Encodable
         foreach ($objects as $object) {
             $data[] = [
                 'method' => 'DELETE',
-                // TODO PATCHV2
                 'path'   => '/'.ParseClient::getMountPath().'classes/'.$object->getClassName().'/'.$object->getObjectId(),
             ];
         }
@@ -1039,7 +1038,6 @@ class ParseObject implements Encodable
                 );
                 $batch[0]->mergeAfterSave($result);
             } else {
-                // TODO PATCHV2
                 foreach ($requests as &$r) {
                     $r['path'] = '/' . ParseClient::getMountPath() . $r['path'];
                 }

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -812,7 +812,8 @@ class ParseObject implements Encodable
         foreach ($objects as $object) {
             $data[] = [
                 'method' => 'DELETE',
-                'path'   => 'classes/'.$object->getClassName().'/'.$object->getObjectId(),
+                // TODO PATCHV2
+                'path'   => '/'.ParseClient::getMountPath().'classes/'.$object->getClassName().'/'.$object->getObjectId(),
             ];
         }
         $sessionToken = null;
@@ -1038,6 +1039,10 @@ class ParseObject implements Encodable
                 );
                 $batch[0]->mergeAfterSave($result);
             } else {
+                // TODO PATCHV2
+                foreach ($requests as &$r) {
+                    $r['path'] = '/' . ParseClient::getMountPath() . $r['path'];
+                }
                 $result = ParseClient::_request(
                     'POST',
                     'batch',


### PR DESCRIPTION
Trying to remove relations via ```$relation->remove($object)``` throws an error in ParseServer, preventing a removal. This is an issue with the PHP SDK, where both the add & remove relation arrays always pass a ```!empty($exampleRelation)``` check due to the following lines in __construct:

```php
$this->relationsToAdd['null'] = [];
$this->relationsToRemove['null'] = [];
```
On trying to add a relation nothing bad seems happens, as the first operation succeeds. When trying to remove a relation however the action never occurs as the server will fail and stop executing on the first element, which contains an empty 'objects' field. Note that this does not happen if both removing and adding objects to a relation in the same request. Parse Server currently has no check for this so it just dies with a TypeError of "Cannot read property 'className' of undefined".

This first come first served issue can be observed by flipping the order of elements here, causing whichever one is first to either succeed or trigger a failure if not set:
```php
return [
    '__op' => 'Batch',
    'ops'  => [$addRelation, $removeRelation],
];
```
For further reference the failure occurs in Schema.js in 'getObjectType', where the following immediately fails when the 'objects' field is empty
```js
return 'relation<' + obj.objects[0].className + '>';
````