### PR TITLE
"endsWith" method added for ParseQuery

### DIFF
--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -243,7 +243,23 @@ class ParseQuery
 
         return $this;
     }
+    
+    /**
+     * Add a constraint to the query that requires a particular key's value to
+     * end with the provided value.
+     *
+     * @param string $key   The key to check.
+     * @param mixed  $value The substring that the value must end with.
+     *
+     * @return ParseQuery Returns this query, so you can chain this call.
+     */
+    public function endsWith($key, $value)
+    {
+        $this->addCondition($key, '$regex', $this->quote($value).'$');
 
+        return $this;
+    }
+    
     /**
      * Returns an associative array of the query constraints.
      *


### PR DESCRIPTION
Adding the missing `endsWith` method to `ParseQuery`
Method signature is same as that of `startsWith`