### PR TITLE
Fix for incorrectly formatted UUID

### DIFF
--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -198,8 +198,7 @@ class ParseUser extends ParseObject
         $uuid_parts = str_split(md5(mt_rand()), 4);
         $data = ['authData' => [
             'anonymous' => [
-                'id' => '{$uuid_parts[0]}{$uuid_parts[1]}-{$uuid_parts[2]}-{$uuid_parts[3]}'
-                .'-{$uuid_parts[4]}-{$uuid_parts[5]}{$uuid_parts[6]}{$uuid_parts[7]}',
+                'id' => $uuid_parts[0].$uuid_parts[1].'-'.$uuid_parts[2].'-'.$uuid_parts[3].'-'.$uuid_parts[4].'-'.$uuid_parts[5].$uuid_parts[6].$uuid_parts[7],
             ],
         ]];
 


### PR DESCRIPTION
Resolves https://github.com/ParsePlatform/parse-php-sdk/issues/245 where the UUID wouldn't be correctly formatted causing anonymous login to fail.