### PR TITLE
Added a check to detect if the mountPath is /

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -155,6 +155,12 @@ final class ParseClient
 
         self::$serverURL = rtrim($serverURL,'/');
         self::$mountPath = trim($mountPath,'/') . '/';
+
+        // check if mount path is root
+        if(self::$mountPath == "/") {
+            // root path should have no mount path
+            self::$mountPath = "";
+        }
     }
 
     /**


### PR DESCRIPTION
This patches issue #252 by checking if the mount path is /. If so the mount path is set to an empty string. 

Previously a mount path of / would end up crafting a url similar to ```https://my.parse.server//classes```, adding an extra slash before the mount path where an actual non-root mount path was normally expected.