### PR TITLE
Add check and conversion to String from Array for 'error' in ParseClient

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -372,6 +372,8 @@ final class ParseClient
 
         $decoded = json_decode($response, true);
         if (isset($decoded['error'])) {
+            // check to convert error to a string, if an array
+            // used to handle an Array 'error' from back4app.com
             $errorMessage = is_array($decoded['error']) ? json_encode($decoded['error']) : $decoded['error'];
             throw new ParseException(
                 $errorMessage,

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -372,8 +372,9 @@ final class ParseClient
 
         $decoded = json_decode($response, true);
         if (isset($decoded['error'])) {
+            $errorMessage = is_array($decoded['error']) ? json_encode($decoded['error']) : $decoded['error'];
             throw new ParseException(
-                $decoded['error'],
+                $errorMessage,
                 isset($decoded['code']) ? $decoded['code'] : 0
             );
         }


### PR DESCRIPTION
The back4app.com Parse Server solution returns a non-standard 'error' value in the response to some requests. #267 references an issue where a normal ParseException cannot be thrown due to an Array being passed in place of the expected String value for an error message.

This resolves the aforementioned issue by adding an additional step to check and encode the value as a json string <i>if</i> it is an array. In cases where it is not, the normal error message is passed along unaltered. This minimal change will allow proper functionality of the php client with the back4app backend, while retaining existing functionality.