### PR TITLE
Fix ParseObject has method for empty array elements

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -229,7 +229,7 @@ class ParseObject implements Encodable
      */
     public function has($key)
     {
-        return isset($this->estimatedData[$key]);
+        return array_key_exists($key, $this->estimatedData);
     }
 
     /**


### PR DESCRIPTION
If Key exist in object but has empty value, "has" method returned false. It was fixed.