### PR TITLE
Update ParseFile to use ParseClient::_request

### DIFF
--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -302,6 +302,7 @@ final class ParseClient
      * @param null   $data         Data to provide with the request.
      * @param bool   $useMasterKey Whether to use the Master Key.
      * @param bool   $appRequest   App request to create or modify a application
+     * @param string $contentType  The content type for this request, default is application/json
      *
      * @throws \Exception
      *
@@ -313,7 +314,8 @@ final class ParseClient
         $sessionToken = null,
         $data = null,
         $useMasterKey = false,
-        $appRequest = false
+        $appRequest = false,
+        $contentType = 'application/json'
     ) {
         if ($data === '[]') {
             $data = '{}';
@@ -334,12 +336,12 @@ final class ParseClient
         curl_setopt($rest, CURLOPT_URL, $url);
         curl_setopt($rest, CURLOPT_RETURNTRANSFER, 1);
         if ($method === 'POST') {
-            $headers[] = 'Content-Type: application/json';
+            $headers[] = 'Content-Type: '.$contentType;
             curl_setopt($rest, CURLOPT_POST, 1);
             curl_setopt($rest, CURLOPT_POSTFIELDS, $data);
         }
         if ($method === 'PUT') {
-            $headers[] = 'Content-Type: application/json';
+            $headers[] = 'Content-Type: '.$contentType;
             curl_setopt($rest, CURLOPT_CUSTOMREQUEST, $method);
             curl_setopt($rest, CURLOPT_POSTFIELDS, $data);
         }


### PR DESCRIPTION
Standardizes upload and delete methods of ParseFile by making both requests via ```ParseClient::_request```.

Updates ```ParseClient::_request``` to take an additional parameter of ```$contentType``` which defaults to the normally expected ```application/json```. This is to accommodate the varying content types that are sent in headers by ```ParseFile```.

Additionally modifies both methods in ParseFile (and ```save```) to optionally take a bool value for using the master key. Originally values for using the master key were hard coded. The default values passed now are the same as they were originally to retain expected default behavior.