### PR TITLE
Made sending of REST API key conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ ParseClient::initialize( $app_id, $rest_key, $master_key );
 ParseClient::setServerURL('https://my-parse-server.com','parse');
 ```
 
+If your server does not use or require a REST key you may initialize the ParseClient as follows, safely omitting the REST key:
+
+```php
+ParseClient::initialize( $app_id, null, $master_key );
+// Users of Parse Server will need to point ParseClient at their remote URL and Mount Point:
+ParseClient::setServerURL('https://my-parse-server.com','parse');
+```
+
 Usage
 -----
 

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -37,7 +37,7 @@ final class ParseClient
     /**
      * The REST API Key.
      *
-     * @var string
+     * @var string|null
      */
     private static $restKey;
 
@@ -455,7 +455,7 @@ final class ParseClient
         }
         if ($useMasterKey) {
             $headers[] = 'X-Parse-Master-Key: '.self::$masterKey;
-        } else {
+        } else if(isset(self::$restKey)) {
             $headers[] = 'X-Parse-REST-API-Key: '.self::$restKey;
         }
         if (self::$forceRevocableSession) {


### PR DESCRIPTION
Altered REST API key to be sent conditionally on it's presence to avoid an unnecessary header being sent to a server that may no longer require a client key. This is in line with updates to parse server, which [no longer require client keys](https://github.com/ParsePlatform/parse-server#user-content-client-key-options) and in response to #225 . 

Passing ```null``` instead of an actual REST API key will result in that header being omitted. Passing a string will retain existing functionality for servers that still require it. Sending a REST API key to servers that do not use it has no effect and is simply ignored.