### PR TITLE
Updated Tests & SDK for Open Source Parse Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 composer.lock
 vendor
+phpunit-test-results

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
 composer.lock
 vendor
+
+# ignore test results
 phpunit-test-results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,23 +11,64 @@ into a single commit. Please provide ample explanation in the commit message.
 Installation
 ------------
 
-Testing the Parse PHP SDK involves some set-up. You'll need to create a Parse
-App just for testing, and deploy some cloud code to it.
+Testing the Parse PHP SDK requires having a working Parse Server instance to run against. 
+Additionally you'll need to add some cloud code to it.
+
+To get started:
 
 * [Get Composer], the PHP package manager.
 * Run "composer install" to download dependencies.
-* Create a new app here: [Create Parse App]
-* Use the Parse CLI to create a Cloud Code folder for the new app.
-* Copy tests/cloudcode/cloud/main.js into the newly created cloud/ folder.
-* Run "parse deploy" in your cloud folder.
-* Paste your App ID, REST API Key, and Master Key in tests/Parse/Helper.php
 
-You should now be able to execute, from project root folder:
+From here you have to setup an instance of parse server.
 
-    ./vendor/bin/phpunit --stderr .
+To get started quickly you can clone and run this [parse server test] project.
+It's setup with the appropriate configuration to run the php sdk test suite. 
+Additionally it handles setting up mongodb for the server.
 
-At present the full suite of tests takes around 20 minutes.
+Alternately you can configure a compatible test server as follows:
+
+* [Setup a local Parse Server instance]
+* Add main.js in tests/cloudcode/cloud/ to your Parse Server configuration as a cloud code file
+* Ensure your App ID, REST API Key, and Master Key match those contained in tests/Parse/Helper.php
+* Add a mock push configuration, for example:
+```json
+{
+    "android":
+    {
+        "senderId": "blank-sender-id",
+        "apiKey": "not-a-real-api-key"
+    }
+}
+```
+* Add a mock email adapter configuration, for example:
+```json
+{
+    "module": "parse-server-simple-mailgun-adapter",
+    "options": {
+        "apiKey": "not-a-real-api-key",
+        "domain": "example.com",
+        "fromAddress": "example@example.com"
+    }
+}
+```
+* Ensure the public url is correct. For a locally hosted instance this is probably ```http://localhost:1337/parse```
+
+
+You should now be able to execute the tests, from project root folder:
+
+    ./vendor/bin/phpunit
+
+The test suite is setup for code coverage if you have [XDebug] installed and setup.
+Coverage is outputted as text and as html in the phpunit-test-results/ directory within the project root.
+
+If you do not have XDebug tests will still run, just without coverage.
+
+Please make sure that any new functionality (or issues) you are working on are covered by tests when possible.
+If you have XDebug setup and can view code coverage please ensure that you do your best to completely cover any new code you are adding.
 
 [Get Composer]: https://getcomposer.org/download/
 [Contributor License Agreement]: https://developers.facebook.com/opensource/cla
 [Create Parse App]: https://parse.com/apps/new
+[XDebug]: https://xdebug.org/
+[parse server test]: https://github.com/montymxb/parse-server-test
+[Setup a local Parse Server instance]: https://github.com/ParsePlatform/parse-server#user-content-locally

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,4 +20,13 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src/Parse</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="phpunit-test-results/" showUncoveredFiles="true"/>
+    </logging>
 </phpunit>

--- a/src/Parse/Internal/AddUniqueOperation.php
+++ b/src/Parse/Internal/AddUniqueOperation.php
@@ -4,6 +4,7 @@ namespace Parse\Internal;
 
 use Parse\ParseClient;
 use Parse\ParseException;
+use Parse\ParseObject;
 
 /**
  * Class AddUniqueOperation - Operation to add unique objects to an array key.

--- a/src/Parse/Internal/ParseRelationOperation.php
+++ b/src/Parse/Internal/ParseRelationOperation.php
@@ -63,6 +63,11 @@ class ParseRelationOperation implements FieldOperation
      */
     private function checkAndAssignClassName($objects)
     {
+        if(!is_array($objects)) {
+            $objects = [$objects];
+
+        }
+
         foreach ($objects as $object) {
             if ($this->targetClassName === null) {
                 $this->targetClassName = $object->getClassName();

--- a/src/Parse/Internal/RemoveOperation.php
+++ b/src/Parse/Internal/RemoveOperation.php
@@ -105,6 +105,12 @@ class RemoveOperation implements FieldOperation
         if (empty($oldValue)) {
             return [];
         }
+
+        if(!is_array($oldValue)) {
+            $oldValue = [$oldValue];
+
+        }
+
         $newValue = [];
         foreach ($oldValue as $oldObject) {
             foreach ($this->objects as $newObject) {

--- a/src/Parse/ParseACL.php
+++ b/src/Parse/ParseACL.php
@@ -548,7 +548,7 @@ class ParseACL implements Encodable
                 return self::$defaultACL;
             }
             if ($last != ParseUser::getCurrentUser()) {
-                self::$defaultACLWithCurrentUser = clone self::$defaultAC;
+                self::$defaultACLWithCurrentUser = clone self::$defaultACL;
                 self::$defaultACLWithCurrentUser->_setShared(true);
                 self::$defaultACLWithCurrentUser->setUserReadAccess(ParseUser::getCurrentUser(), true);
                 self::$defaultACLWithCurrentUser->setUserWriteAccess(ParseUser::getCurrentUser(), true);

--- a/src/Parse/ParseApp.php
+++ b/src/Parse/ParseApp.php
@@ -24,7 +24,7 @@ class ParseApp
             'apps',
             null,
             null,
-            false,
+            true,
             true
         );
 
@@ -47,7 +47,7 @@ class ParseApp
             'apps/'.$application_id,
             null,
             null,
-            false,
+            true,
             true
         );
 
@@ -70,7 +70,7 @@ class ParseApp
             'apps',
             null,
             json_encode($data),
-            false,
+            true,
             true
         );
 
@@ -94,7 +94,7 @@ class ParseApp
             'apps/'.$application_id,
             null,
             json_encode($data),
-            false,
+            true,
             true
         );
 

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -321,8 +321,10 @@ final class ParseClient
             $data = '{}';
         }
         if ($appRequest) {
+            // 'app' requests are not available in open source parse-server
             self::assertAppInitialized();
             $headers = self::_getAppRequestHeaders();
+
         } else {
             self::assertParseInitialized();
             $headers = self::_getRequestHeaders($sessionToken, $useMasterKey);

--- a/src/Parse/ParseConfig.php
+++ b/src/Parse/ParseConfig.php
@@ -38,4 +38,10 @@ class ParseConfig
     {
         $this->currentConfig = $config;
     }
+
+    public function getConfig()
+    {
+        return $this->currentConfig;
+
+    }
 }

--- a/src/Parse/ParseFile.php
+++ b/src/Parse/ParseFile.php
@@ -109,7 +109,17 @@ class ParseFile implements Encodable
      */
     public function getMimeType()
     {
-        return $this->mimeType;
+        if(isset($this->mimeType)) {
+            // return the mime type
+            return $this->mimeType;
+
+        } else {
+            // return an inferred mime type instead
+            $fileParts = explode('.', $this->getName());
+            $extension = array_pop($fileParts);
+            return $this->getMimeTypeForExtension($extension);
+
+        }
     }
 
     /**

--- a/src/Parse/ParseHooks.php
+++ b/src/Parse/ParseHooks.php
@@ -26,11 +26,7 @@ class ParseHooks
             true
         );
 
-        if (!isset($result['results'])) {
-            throw new ParseException('Hooks functions not found.', 101);
-        }
-
-        return $result['results'];
+        return $result;
     }
 
     /**
@@ -52,11 +48,7 @@ class ParseHooks
             true
         );
 
-        if (!isset($result['results'])) {
-            throw new ParseException('Hooks functions not found.', 101);
-        }
-
-        return $result['results'];
+        return $result;
     }
 
     /**
@@ -76,11 +68,7 @@ class ParseHooks
             true
         );
 
-        if (!isset($result['results'])) {
-            throw new ParseException('Hooks triggers not found.', 101);
-        }
-
-        return $result['results'];
+        return $result;
     }
 
     /**
@@ -102,10 +90,6 @@ class ParseHooks
             null,
             true
         );
-
-        if (!isset($result['results'])) {
-            throw new ParseException('Hooks trigger not found.', 101);
-        }
 
         return $result;
     }

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -1366,6 +1366,5 @@ class ParseObject implements Encodable
         } else {
             return new ParseQuery($subclass);
         }
-
     }
 }

--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -230,6 +230,7 @@ class ParseObject implements Encodable
     public function has($key)
     {
         return isset($this->estimatedData[$key]);
+
     }
 
     /**
@@ -1365,5 +1366,6 @@ class ParseObject implements Encodable
         } else {
             return new ParseQuery($subclass);
         }
+
     }
 }

--- a/src/Parse/ParseRelation.php
+++ b/src/Parse/ParseRelation.php
@@ -49,30 +49,6 @@ class ParseRelation
     }
 
     /**
-     * Makes sure that this relation has the right parent and key.
-     *
-     * @param $parent
-     * @param $key
-     *
-     * @throws \Exception
-     */
-    private function ensureParentAndKey($parent, $key)
-    {
-        if (!$this->parent) {
-            $this->parent = $parent;
-        }
-        if (!$this->key) {
-            $this->key = $key;
-        }
-        if ($this->parent !== $parent) {
-            throw new Exception('Internal Error. Relation retrieved from two different Objects.');
-        }
-        if ($this->key !== $key) {
-            throw new Exception('Internal Error. Relation retrieved from two different keys.');
-        }
-    }
-
-    /**
      * Adds a ParseObject or an array of ParseObjects to the relation.
      *
      * @param mixed $objects The item or items to add.

--- a/src/Parse/ParseRole.php
+++ b/src/Parse/ParseRole.php
@@ -85,6 +85,13 @@ class ParseRole extends ParseObject
         return $this->getRelation('roles');
     }
 
+    /**
+     * Handles pre-saving of this role
+     * Calls ParseObject::save to finish
+     *
+     * @param bool $useMasterKey
+     * @throws ParseException
+     */
     public function save($useMasterKey = false)
     {
         if (!$this->getACL()) {
@@ -96,6 +103,17 @@ class ParseRole extends ParseObject
             throw new ParseException(
                 'Roles must have a name.'
             );
+        }
+        if($this->getObjectId() === null) {
+            // Not yet saved, verify this name is not taken
+            // ParseServer does not validate duplicate role names as of parse-server v2.3.2
+            $query = new ParseQuery('_Role');
+            $query->equalTo('name', $this->getName());
+            if($query->count(true) > 0) {
+                throw new ParseException("Cannot add duplicate role name of '{$this->getName()}'");
+
+            }
+
         }
 
         return parent::save($useMasterKey);

--- a/src/Parse/ParseUser.php
+++ b/src/Parse/ParseUser.php
@@ -344,7 +344,6 @@ class ParseUser extends ParseObject
             foreach ($userData as $key => $value) {
                 $user->set($key, $value);
             }
-            $user->_opSetQueue = [];
             static::$currentUser = $user;
 
             return $user;

--- a/tests/Parse/AddOperationTest.php
+++ b/tests/Parse/AddOperationTest.php
@@ -40,7 +40,7 @@ class AddOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadObjects()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'AddOperation requires an array.');
         new AddOperation('not an array');
 
@@ -84,7 +84,7 @@ class AddOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Operation is invalid after previous operation.');
         $addOp = new AddOperation([
             'key1'          => 'value1'

--- a/tests/Parse/AddOperationTest.php
+++ b/tests/Parse/AddOperationTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 1/30/17
+ * Time: 10:20 AM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\Internal\AddOperation;
+use Parse\Internal\DeleteOperation;
+use Parse\Internal\SetOperation;
+use Parse\ParseException;
+
+class AddOperationTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Helper::setUp();
+    }
+
+    /**
+     * @group add-op
+     */
+    public function testAddOperation()
+    {
+        $objects = [
+            'key'   => 'val'
+        ];
+        $addOp = new AddOperation($objects);
+
+        $this->assertEquals($objects, $addOp->getValue());
+
+    }
+
+    /**
+     * @group add-op
+     */
+    public function testBadObjects()
+    {
+        $this->expectException(ParseException::class,
+            'AddOperation requires an array.');
+        new AddOperation('not an array');
+
+    }
+
+    /**
+     * @group add-op
+     */
+    public function testMergePrevious()
+    {
+        $addOp = new AddOperation([
+            'key1'          => 'value1'
+        ]);
+
+        $this->assertEquals($addOp, $addOp->_mergeWithPrevious(null));
+
+        // check delete op
+        $merged = $addOp->_mergeWithPrevious(new DeleteOperation());
+        $this->assertTrue($merged instanceof SetOperation);
+
+        // check set op
+        $merged = $addOp->_mergeWithPrevious(new SetOperation('newvalue'));
+        $this->assertTrue($merged instanceof SetOperation);
+        $this->assertEquals([
+            'newvalue',
+            'key1'  => 'value1'
+        ], $merged->getValue(), 'Value was not as expected');
+
+        // check self
+        $merged = $addOp->_mergeWithPrevious(new AddOperation(['key2'   => 'value2']));
+        $this->assertTrue($merged instanceof SetOperation);
+        $this->assertEquals([
+            'key2'  => 'value2',
+            'key1'  => 'value1'
+        ], $merged->getValue(), 'Value was not as expected');
+
+    }
+
+    /**
+     * @group add-op
+     */
+    public function testInvalidMerge()
+    {
+        $this->expectException(ParseException::class,
+            'Operation is invalid after previous operation.');
+        $addOp = new AddOperation([
+            'key1'          => 'value1'
+        ]);
+        $addOp->_mergeWithPrevious(new \DateTime());
+
+    }
+}

--- a/tests/Parse/AddUniqueOperationTest.php
+++ b/tests/Parse/AddUniqueOperationTest.php
@@ -50,7 +50,7 @@ class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadObjects()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'AddUniqueOperation requires an array.');
         $addUnique = new AddUniqueOperation('not-an-array');
 
@@ -114,7 +114,7 @@ class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Operation is invalid after previous operation.');
         $addOp = new AddUniqueOperation([
             'key1'          => 'value1'

--- a/tests/Parse/AddUniqueOperationTest.php
+++ b/tests/Parse/AddUniqueOperationTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 1/30/17
+ * Time: 10:34 AM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\Internal\AddUniqueOperation;
+use Parse\Internal\DeleteOperation;
+use Parse\Internal\IncrementOperation;
+use Parse\Internal\SetOperation;
+use Parse\ParseClient;
+use Parse\ParseException;
+use Parse\ParseObject;
+use Symfony\Component\Validator\Constraints\DateTime;
+
+class AddUniqueOperationTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Helper::setUp();
+    }
+
+    public function tearDown()
+    {
+        Helper::clearClass('TestObject');
+    }
+
+    /**
+     * @group add-unique-op
+     */
+    public function testAddUniqueOp()
+    {
+        $objects = [
+            'key1'  => 'val1',
+            'key2'  => 'val2'
+        ];
+        $addUnique = new AddUniqueOperation($objects);
+
+        $this->assertEquals($objects, $addUnique->getValue());
+
+    }
+
+    /**
+     * @group add-unique-op
+     */
+    public function testBadObjects()
+    {
+        $this->expectException(ParseException::class,
+            'AddUniqueOperation requires an array.');
+        $addUnique = new AddUniqueOperation('not-an-array');
+
+    }
+
+    /**
+     * @group add-unique-op
+     */
+    public function testEncode()
+    {
+        $objects = [
+            'key1'  => 'val1',
+            'key2'  => 'val2'
+        ];
+        $addUnique = new AddUniqueOperation($objects);
+
+        $encoded = $addUnique->_encode();
+
+        $this->assertEquals([
+            '__op'      => 'AddUnique',
+            'objects'   => ParseClient::_encode($objects, true)
+        ], $encoded);
+
+    }
+
+    /**
+     * @group add-unique-op
+     */
+    public function testMergePrevious()
+    {
+        $addOp = new AddUniqueOperation([
+            'key1'          => 'value1'
+        ]);
+
+        $this->assertEquals($addOp, $addOp->_mergeWithPrevious(null));
+
+        // check delete op
+        $merged = $addOp->_mergeWithPrevious(new DeleteOperation());
+        $this->assertTrue($merged instanceof SetOperation);
+
+        // check set op
+        $merged = $addOp->_mergeWithPrevious(new SetOperation('newvalue'));
+        $this->assertTrue($merged instanceof SetOperation);
+        $this->assertEquals([
+            'newvalue',
+            'value1'
+        ], $merged->getValue(), 'Value was not as expected');
+
+        // check self
+        $merged = $addOp->_mergeWithPrevious(new AddUniqueOperation(['key2'   => 'value2']));
+        $this->assertTrue($merged instanceof AddUniqueOperation);
+        $this->assertEquals([
+            'key2'  => 'value2',
+            'value1'
+        ], $merged->getValue(), 'Value was not as expected');
+
+    }
+
+    /**
+     * @group add-unique-op
+     */
+    public function testInvalidMerge()
+    {
+        $this->expectException(ParseException::class,
+            'Operation is invalid after previous operation.');
+        $addOp = new AddUniqueOperation([
+            'key1'          => 'value1'
+        ]);
+        $addOp->_mergeWithPrevious(new IncrementOperation());
+
+    }
+
+    /**
+     * @group add-unique-op
+     */
+    public function testApply()
+    {
+        // test a null old value
+        $objects = [
+            'key1'  => 'value1'
+        ];
+        $addOp = new AddUniqueOperation($objects);
+        $this->assertEquals($objects, $addOp->_apply(null, null, null));
+
+        $addOp = new AddUniqueOperation([
+            'key'    => 'string'
+        ]);
+        $oldValue = $addOp->_apply('string', null, null);
+        $this->assertEquals(['string'], $oldValue);
+
+        // test saving an object
+        $obj = new \DateTime();
+        $addOp = new AddUniqueOperation([
+            'object'    => $obj
+        ]);
+        $oldValue = $addOp->_apply($obj, null, null);
+        $this->assertEquals($obj, $oldValue[0]);
+
+        // create a Parse object to save
+        $obj1 = new ParseObject('TestObject');
+        $obj1->set('name', 'montymxb');
+        $obj1->save();
+
+        // test a saved parse object as the old value
+        $addOp = new AddUniqueOperation([
+            'object'    => $obj1
+        ]);
+        $oldValue = $addOp->_apply($obj1, null, null);
+        $this->assertEquals($obj1, $oldValue[0]);
+
+    }
+}

--- a/tests/Parse/ConfigMock.php
+++ b/tests/Parse/ConfigMock.php
@@ -8,6 +8,10 @@ class ConfigMock extends ParseConfig
 {
     public function __construct()
     {
-        $this->setConfig(['foo' => 'bar', 'some' => 1]);
+        $this->setConfig([
+            'foo'       => 'bar',
+            'some'      => 1,
+            'another'   => '<value>'
+        ]);
     }
 }

--- a/tests/Parse/Helper.php
+++ b/tests/Parse/Helper.php
@@ -8,6 +8,30 @@ use Parse\ParseQuery;
 
 class Helper
 {
+    /**
+     * Application Id
+     * @var string
+     */
+    public static $appId      = 'app-id-here';
+
+    /**
+     * Rest API Key
+     * @var string
+     */
+    public static $restKey    = 'rest-api-key-here';
+
+    /**
+     * Master Key
+     * @var string
+     */
+    public static $masterKey  = 'master-key-here';
+
+    /**
+     * Account Key (for parse.com)
+     * @var string
+     */
+    public static $accountKey = 'account-key';
+
     public static function setUp()
     {
         ini_set('error_reporting', E_ALL);
@@ -15,13 +39,18 @@ class Helper
         date_default_timezone_set('UTC');
 
         ParseClient::initialize(
-            'app-id-here',
-            'rest-api-key-here',
-            'master-key-here',
+            self::$appId,
+            self::$restKey,
+            self::$masterKey,
             true,
-            'account-key-here'
+            self::$accountKey
         );
-        ParseClient::setServerURL('http://localhost:1337/parse');
+        self::setServerURL();
+    }
+
+    public static function setServerURL()
+    {
+        ParseClient::setServerURL('http://localhost:1337','parse');
     }
 
     public static function tearDown()
@@ -37,5 +66,17 @@ class Helper
             },
             true
         );
+    }
+
+    public static function setUpWithoutCURLExceptions()
+    {
+        ParseClient::initialize(
+            self::$appId,
+            self::$restKey,
+            self::$masterKey,
+            false,
+            self::$accountKey
+        );
+
     }
 }

--- a/tests/Parse/Helper.php
+++ b/tests/Parse/Helper.php
@@ -32,6 +32,7 @@ class Helper
      */
     public static $accountKey = 'account-key';
 
+
     public static function setUp()
     {
         ini_set('error_reporting', E_ALL);

--- a/tests/Parse/IncrementOperationTest.php
+++ b/tests/Parse/IncrementOperationTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 1/30/17
+ * Time: 11:00 AM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\Internal\AddOperation;
+use Parse\Internal\DeleteOperation;
+use Parse\Internal\IncrementOperation;
+use Parse\Internal\SetOperation;
+use Parse\ParseException;
+
+class IncrementOperationTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Helper::setUp();
+    }
+
+    /**
+     * @group increment-op
+     */
+    public function testIncrementOperation()
+    {
+        $addOp = new IncrementOperation(32);
+        $this->assertEquals(32, $addOp->getValue());
+
+    }
+
+    /**
+     * @group increment-op
+     */
+    public function testMergePrevious()
+    {
+        $addOp = new IncrementOperation();
+
+        $this->assertEquals($addOp, $addOp->_mergeWithPrevious(null));
+
+        // check delete op
+        $merged = $addOp->_mergeWithPrevious(new DeleteOperation());
+        $this->assertTrue($merged instanceof SetOperation);
+
+        // check set op
+        $merged = $addOp->_mergeWithPrevious(new SetOperation(12));
+        $this->assertTrue($merged instanceof SetOperation);
+        $this->assertEquals(13, $merged->getValue(), 'Value was not as expected');
+
+        // check self
+        $merged = $addOp->_mergeWithPrevious(new IncrementOperation(32));
+        $this->assertTrue($merged instanceof IncrementOperation);
+        $this->assertEquals(33, $merged->getValue(), 'Value was not as expected');
+
+    }
+
+    /**
+     * @group increment-op
+     */
+    public function testInvalidMerge()
+    {
+        $this->expectException(ParseException::class,
+            'Operation is invalid after previous operation.');
+        $addOp = new IncrementOperation();
+        $addOp->_mergeWithPrevious(new AddOperation(['key'  => 'value']));
+
+    }
+}

--- a/tests/Parse/IncrementOperationTest.php
+++ b/tests/Parse/IncrementOperationTest.php
@@ -62,7 +62,7 @@ class IncrementOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Operation is invalid after previous operation.');
         $addOp = new IncrementOperation();
         $addOp->_mergeWithPrevious(new AddOperation(['key'  => 'value']));

--- a/tests/Parse/IncrementTest.php
+++ b/tests/Parse/IncrementTest.php
@@ -217,7 +217,7 @@ class IncrementTest extends \PHPUnit_Framework_TestCase
         $objAgain->increment('randomkey');
         $this->setExpectedException(
             'Parse\ParseException',
-            'invalid type for key'
+            'schema mismatch for TestObject.randomkey; expected String but got Number'
         );
         $objAgain->save();
     }
@@ -234,8 +234,8 @@ class IncrementTest extends \PHPUnit_Framework_TestCase
         $obj->save();
         $this->setExpectedException(
             'Parse\ParseException',
-            'invalid type for key randomkeyagain, '.
-            'expected number, but got string'
+            'schema mismatch for TestObject.randomkeyagain; '.
+            'expected Number but got String'
         );
         $objAgain->save();
     }

--- a/tests/Parse/ParseACLTest.php
+++ b/tests/Parse/ParseACLTest.php
@@ -451,7 +451,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
      * @group acl-invalid
      */
     public function testCreatingACLWithInvalidId() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'Tried to create an ACL with an invalid userId.');
 
         ParseACL::_createACLFromJSON([
@@ -464,7 +464,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
      * @group acl-invalid
      */
     public function testCreatingWithBadAccessType() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'Tried to create an ACL with an invalid permission type.');
 
         ParseACL::_createACLFromJSON([
@@ -479,7 +479,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
      * @group acl-invalid
      */
     public function testCreatingWithInvalidPermissionValue() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'Tried to create an ACL with an invalid permission value.');
 
         ParseACL::_createACLFromJSON([
@@ -552,7 +552,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testSettingUserReadAccessWithoutId() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'cannot setReadAccess for a user with null id');
 
         $acl = new ParseACL();
@@ -561,7 +561,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testGettingUserReadAccessWithoutId() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'cannot getReadAccess for a user with null id');
 
         $acl = new ParseACL();
@@ -570,7 +570,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testSettingUserWriteAccessWithoutId() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'cannot setWriteAccess for a user with null id');
 
         $acl = new ParseACL();
@@ -579,7 +579,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testGettingUserWriteAccessWithoutId() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'cannot getWriteAccess for a user with null id');
 
         $acl = new ParseACL();
@@ -625,7 +625,7 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testUnsavedRoleAdded() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'Roles must be saved to the server before they can be used in an ACL.');
 
         $acl = new ParseACL();

--- a/tests/Parse/ParseAnalyticsTest.php
+++ b/tests/Parse/ParseAnalyticsTest.php
@@ -77,4 +77,22 @@ class ParseAnalyticsTest extends \PHPUnit_Framework_TestCase
         ];
         $this->assertAnalyticsValidation('testDate', $params, $expected);
     }
+
+    public function testBadKeyDimension() {
+        $this->expectException(
+            '\Exception',
+            'Dimensions expected string keys and values.'
+        );
+        ParseAnalytics::track('event', [1=>'good-value']);
+
+    }
+
+    public function testBadValueDimension() {
+        $this->expectException(
+            '\Exception',
+            'Dimensions expected string keys and values.'
+        );
+        ParseAnalytics::track('event', ['good-key'=>1]);
+
+    }
 }

--- a/tests/Parse/ParseAnalyticsTest.php
+++ b/tests/Parse/ParseAnalyticsTest.php
@@ -79,7 +79,7 @@ class ParseAnalyticsTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testBadKeyDimension() {
-        $this->expectException(
+        $this->setExpectedException(
             '\Exception',
             'Dimensions expected string keys and values.'
         );
@@ -88,7 +88,7 @@ class ParseAnalyticsTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testBadValueDimension() {
-        $this->expectException(
+        $this->setExpectedException(
             '\Exception',
             'Dimensions expected string keys and values.'
         );

--- a/tests/Parse/ParseAppTest.php
+++ b/tests/Parse/ParseAppTest.php
@@ -14,7 +14,7 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testFetchingApps()
     {
-        $this->expectException('Parse\ParseException',
+        $this->setExpectedException('Parse\ParseException',
             'unauthorized');
 
         self::_createApp(self::_getNewName());
@@ -26,7 +26,7 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testFetchSingleApp()
     {
-        $this->expectException('Parse\ParseException',
+        $this->setExpectedException('Parse\ParseException',
             'unauthorized');
 
         $app_created = self::_createApp(self::_getNewName());
@@ -46,7 +46,7 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testCreateApp()
     {
-        $this->expectException('Parse\ParseException',
+        $this->setExpectedException('Parse\ParseException',
             'unauthorized');
 
         $app_name = self::_getNewName();
@@ -64,7 +64,7 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testNameAlreadyInAccount()
     {
-        $this->expectException('Parse\ParseException',
+        $this->setExpectedException('Parse\ParseException',
             'unauthorized');
 
         $app_name = self::_getNewName();
@@ -81,7 +81,7 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testUpdateApp()
     {
-        $this->expectException('Parse\ParseException',
+        $this->setExpectedException('Parse\ParseException',
             'unauthorized');
 
         $app_name = self::_getNewName();

--- a/tests/Parse/ParseAppTest.php
+++ b/tests/Parse/ParseAppTest.php
@@ -14,6 +14,9 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testFetchingApps()
     {
+        $this->expectException('Parse\ParseException',
+            'unauthorized');
+
         self::_createApp(self::_getNewName());
         self::_createApp(self::_getNewName());
 
@@ -23,6 +26,9 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testFetchSingleApp()
     {
+        $this->expectException('Parse\ParseException',
+            'unauthorized');
+
         $app_created = self::_createApp(self::_getNewName());
 
         $app = ParseApp::fetchApp($app_created['applicationId']);
@@ -34,12 +40,15 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
     {
         $invalid_application_id = '1YkU7V110nEDUqU7ctCEbLr6xcgQgdEkePuBaw6P';
 
-        $this->setExpectedException('Parse\ParseException', 'requested resource was not found');
+        $this->setExpectedException('Parse\ParseException', 'unauthorized');
         ParseApp::fetchApp($invalid_application_id);
     }
 
     public function testCreateApp()
     {
+        $this->expectException('Parse\ParseException',
+            'unauthorized');
+
         $app_name = self::_getNewName();
 
         $app = ParseApp::createApp([
@@ -55,6 +64,9 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testNameAlreadyInAccount()
     {
+        $this->expectException('Parse\ParseException',
+            'unauthorized');
+
         $app_name = self::_getNewName();
 
         ParseApp::createApp([
@@ -69,6 +81,9 @@ class ParseAppTest extends PHPUnit_Framework_TestCase
 
     public function testUpdateApp()
     {
+        $this->expectException('Parse\ParseException',
+            'unauthorized');
+
         $app_name = self::_getNewName();
         $updated_name = self::_getNewName();
         $this->assertNotEquals($app_name, $updated_name);

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -39,7 +39,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      * @group client-not-initialized
      */
     public function testParseNotInitialized() {
-        $this->expectException(
+        $this->setExpectedException(
             '\Exception',
             'You must call Parse::initialize() before making any requests.'
         );
@@ -62,7 +62,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      * @group client-not-initialized
      */
     public function testAppNotNotInitialized() {
-        $this->expectException(
+        $this->setExpectedException(
             '\Exception',
             'You must call Parse::initialize(..., $accountKey) before making any requests.'
         );
@@ -111,7 +111,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      * @group client-app-request
      */
     public function testAppRequestHeadersMissingAccountKey() {
-        $this->expectException(
+        $this->setExpectedException(
             '\InvalidArgumentException',
             'A account key is required and can not be null or empty'
         );
@@ -246,7 +246,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      * @group client-test
      */
     public function testBadServerURL() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'Invalid Server URL.');
         ParseClient::setServerURL(null, 'parse');
 
@@ -256,7 +256,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      * @group client-test
      */
     public function testBadMountPath() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'Invalid Mount Path.');
         ParseClient::setServerURL('https://example.com', null);
 
@@ -266,7 +266,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      * @group encoding-error
      */
     public function testEncodingError() {
-        $this->expectException('\Exception',
+        $this->setExpectedException('\Exception',
             'Invalid type encountered.');
         ParseClient::_encode(new Helper(), false);
 
@@ -352,8 +352,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      * @group curl-exceptions
      */
     public function testCurlExceptions() {
-        $this->expectException('\Parse\ParseException',
-            "Couldn't resolve host '404.example.com'");
+        $this->setExpectedException('\Parse\ParseException', '', 6);
 
         ParseClient::setServerURL('http://404.example.com', 'parse');
         ParseClient::_request(
@@ -367,7 +366,7 @@ class ParseClientTest extends \PHPUnit_Framework_TestCase
      * @group client-bad-request
      */
     public function testBadRequest() {
-        $this->expectException('\Parse\ParseException',
+        $this->setExpectedException('\Parse\ParseException',
             "Bad Request");
         ParseClient::setServerURL('http://example.com', '/');
         ParseClient::_request(

--- a/tests/Parse/ParseClientTest.php
+++ b/tests/Parse/ParseClientTest.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 1/29/17
+ * Time: 10:21 AM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\ParseClient;
+use Parse\ParseException;
+use Parse\ParseInstallation;
+use Parse\ParseMemoryStorage;
+use Parse\ParseObject;
+use Parse\ParseRole;
+use Parse\ParseSessionStorage;
+use Parse\ParseUser;
+
+class ParseClientTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Helper::setUp();
+    }
+
+    public function setUp()
+    {
+        Helper::setServerURL();
+    }
+
+    public function tearDown()
+    {
+        Helper::tearDown();
+    }
+
+    /**
+     * @group client-not-initialized
+     */
+    public function testParseNotInitialized() {
+        $this->expectException(
+            '\Exception',
+            'You must call Parse::initialize() before making any requests.'
+        );
+
+        ParseClient::initialize(
+            null,
+            null,
+            null
+        );
+
+        ParseClient::_request(
+            '',
+            ''
+        );
+
+
+    }
+
+    /**
+     * @group client-not-initialized
+     */
+    public function testAppNotNotInitialized() {
+        $this->expectException(
+            '\Exception',
+            'You must call Parse::initialize(..., $accountKey) before making any requests.'
+        );
+
+        ParseClient::initialize(
+            null,
+            null,
+            null
+        );
+
+        ParseClient::_request(
+            '',
+            '',
+            null,
+            null,
+            false,
+            true
+        );
+
+    }
+
+    /**
+     * @group client-app-request
+     */
+    public function testAppRequestHeaders() {
+
+        // call init
+        ParseClient::initialize(
+            Helper::$appId,
+            Helper::$restKey,
+            Helper::$masterKey,
+            true,
+            Helper::$accountKey
+        );
+
+        $headers = ParseClient::_getAppRequestHeaders();
+
+        $this->assertEquals([
+            'X-Parse-Account-Key: '.Helper::$accountKey,
+            'Expect: '
+        ], $headers);
+
+    }
+
+    /**
+     * @group client-app-request
+     */
+    public function testAppRequestHeadersMissingAccountKey() {
+        $this->expectException(
+            '\InvalidArgumentException',
+            'A account key is required and can not be null or empty'
+        );
+
+        ParseClient::initialize(
+            null,
+            null,
+            null
+        );
+
+        ParseClient::_getAppRequestHeaders();
+
+    }
+
+    /**
+     * @group client-init
+     */
+    public function testInitialize() {
+
+        // unregister associated sub classes
+        ParseUser::_unregisterSubclass();
+        ParseRole::_unregisterSubclass();
+        ParseInstallation::_unregisterSubclass();
+
+        // unset storage
+        ParseClient::_unsetStorage();
+
+        // call init
+        ParseClient::initialize(
+            Helper::$appId,
+            Helper::$restKey,
+            Helper::$masterKey,
+            true,
+            Helper::$accountKey
+        );
+
+        // verify these classes are now registered
+        $this->assertTrue(ParseObject::hasRegisteredSubclass('_User'));
+        $this->assertTrue(ParseObject::hasRegisteredSubclass('_Role'));
+        $this->assertTrue(ParseObject::hasRegisteredSubclass('_Installation'));
+
+        // verify storage is now set
+        $this->assertNotNull(ParseClient::getStorage());
+
+    }
+
+    /**
+     * @group client-storage
+     */
+    public function testStorage() {
+
+        // unset storage
+        ParseClient::_unsetStorage();
+
+        // call init
+        ParseClient::initialize(
+            Helper::$appId,
+            Helper::$restKey,
+            Helper::$masterKey,
+            true,
+            Helper::$accountKey
+        );
+
+        $storage = ParseClient::getStorage();
+        $this->assertTrue($storage instanceof ParseMemoryStorage,
+            'Not an instance of ParseMemoryStorage');
+
+        /* TODO can't get session storage test to pass properly
+        // unset storage
+        ParseClient::_unsetStorage();
+
+        // indicate we should not use cookies
+        ini_set("session.use_cookies", 0);
+        // indicate we can use something other than cookies
+        ini_set("session.use_only_cookies", 0);
+        // enable transparent sid support, for url based sessions
+        ini_set("session.use_trans_sid", 1);
+        // clear cache control for session pages
+        ini_set("session.cache_limiter", "");
+
+        // start a session
+        session_start();
+
+        // call init
+        ParseClient::initialize(
+            Helper::$appId,
+            Helper::$restKey,
+            Helper::$masterKey,
+            true,
+            Helper::$accountKey
+        );
+
+        $storage = ParseClient::getStorage();
+        $this->assertTrue($storage instanceof ParseSessionStorage,
+            'Not an instance of ParseSessionStorage');
+        */
+    }
+
+    /**
+     * @group client-test
+     */
+    public function testSetServerURL() {
+        // add extra slashes to test removal
+        ParseClient::setServerURL('https://example.com//', '//parse//');
+
+        // verify APIUrl
+        $this->assertEquals(
+            'https://example.com/parse/',
+            ParseClient::getAPIUrl());
+
+        // verify mount path
+        $this->assertEquals(
+            'parse/',
+            ParseClient::getMountPath()
+        );
+
+    }
+
+    /**
+     * @group client-test
+     */
+    public function testRootMountPath() {
+        ParseClient::setServerURL('https://example.com', '/');
+        $this->assertEquals(
+            '',
+            ParseClient::getMountPath(),
+            'Mount path was not reduced to an empty sequence for root');
+
+    }
+
+    /**
+     * @group client-test
+     */
+    public function testBadServerURL() {
+        $this->expectException('\Exception',
+            'Invalid Server URL.');
+        ParseClient::setServerURL(null, 'parse');
+
+    }
+
+    /**
+     * @group client-test
+     */
+    public function testBadMountPath() {
+        $this->expectException('\Exception',
+            'Invalid Mount Path.');
+        ParseClient::setServerURL('https://example.com', null);
+
+    }
+
+    /**
+     * @group encoding-error
+     */
+    public function testEncodingError() {
+        $this->expectException('\Exception',
+            'Invalid type encountered.');
+        ParseClient::_encode(new Helper(), false);
+
+    }
+
+    /**
+     * @group client-decoding
+     */
+    public function testDecodingStdClass() {
+        $obj = new \stdClass();
+        $obj->property = 'value';
+
+        $this->assertEquals([
+            'property' => 'value'
+        ], ParseClient::_decode($obj));
+
+        $emptyClass = new \stdClass();
+        $this->assertEquals($emptyClass, ParseClient::_decode($emptyClass));
+
+    }
+
+    /**
+     * @group timeouts
+     */
+    public function testTimeout() {
+
+        ParseClient::setTimeout(3000);
+
+        // perform a standard save
+        $obj = new ParseObject('TestingClass');
+        $obj->set('key', 'value');
+        $obj->save(true);
+
+        $this->assertNotNull($obj->getObjectId());
+
+        $obj->destroy();
+
+        // clear timeout
+        ParseClient::setTimeout(null);
+
+    }
+
+    /**
+     * @group timeouts
+     */
+    public function testConnectionTimeout() {
+        ParseClient::setConnectionTimeout(3000);
+
+        // perform a standard save
+        $obj = new ParseObject('TestingClass');
+        $obj->set('key', 'value');
+        $obj->save();
+
+        $this->assertNotNull($obj->getObjectId());
+
+        $obj->destroy();
+
+        // clear timeout
+        ParseClient::setConnectionTimeout(null);
+
+    }
+
+    /**
+     * @group curl-exceptions
+     */
+    public function testNoCurlExceptions() {
+        Helper::setUpWithoutCURLExceptions();
+
+        ParseClient::setServerURL('http://404.example.com', 'parse');
+        $result = ParseClient::_request(
+            'GET',
+            'not-a-real-endpoint-to-reach',
+            null);
+
+        $this->assertFalse($result);
+
+        // put back
+        Helper::setUp();
+
+    }
+
+    /**
+     * @group curl-exceptions
+     */
+    public function testCurlExceptions() {
+        $this->expectException('\Parse\ParseException',
+            "Couldn't resolve host '404.example.com'");
+
+        ParseClient::setServerURL('http://404.example.com', 'parse');
+        ParseClient::_request(
+            'GET',
+            'not-a-real-endpoint-to-reach',
+            null);
+
+    }
+
+    /**
+     * @group client-bad-request
+     */
+    public function testBadRequest() {
+        $this->expectException('\Parse\ParseException',
+            "Bad Request");
+        ParseClient::setServerURL('http://example.com', '/');
+        ParseClient::_request(
+            'GET',
+            '',
+            null);
+
+    }
+}

--- a/tests/Parse/ParseCloudTest.php
+++ b/tests/Parse/ParseCloudTest.php
@@ -5,6 +5,7 @@ namespace Parse\Test;
 use Parse\ParseCloud;
 use Parse\ParseGeoPoint;
 use Parse\ParseObject;
+use Parse\ParseUser;
 
 class ParseCloudTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,27 +14,94 @@ class ParseCloudTest extends \PHPUnit_Framework_TestCase
         Helper::setUp();
     }
 
+    public function tearDown()
+    {
+        $user = ParseUser::getCurrentUser();
+        if(isset($user)) {
+            ParseUser::logOut();
+            $user->destroy(true);
+
+        }
+    }
+
+    /**
+     * @group cloud-code
+     */
+    public function testFunctionCall() {
+        $response = ParseCloud::run('bar', [
+            'key1'  => 'value2',
+            'key2'  => 'value1'
+        ]);
+
+        $this->assertEquals('Foo', $response);
+
+    }
+
+    public function testFunctionCallWithUser() {
+        $user = new ParseUser();
+        $user->setUsername("someuser");
+        $user->setPassword("somepassword");
+        $user->signUp();
+
+        $response = ParseCloud::run('bar', [
+            'key1'  => 'value2',
+            'key2'  => 'value1'
+        ]);
+
+        $this->assertEquals('Foo', $response);
+
+        ParseUser::logOut();
+        $user->destroy(true);
+
+    }
+
+    /**
+     * @group cloud-code
+     */
+    public function testFunctionCallException() {
+        $this->expectException('\Parse\ParseException',
+            'bad stuff happened');
+
+        ParseCloud::run('bar', [
+            'key1'  => 'value1',
+            'key2'  => 'value2'
+        ]);
+    }
+
+    /**
+     * @group cloud-code
+     */
     public function testFunctionsWithObjectParamsFails()
     {
+        // login as user
         $obj = ParseObject::create('SomeClass');
         $obj->set('name', 'Zanzibar');
         $obj->save();
         $params = ['key1' => $obj];
         $this->setExpectedException('\Exception', 'ParseObjects not allowed');
         ParseCloud::run('foo', $params);
+
     }
 
+    /**
+     * @group cloud-code
+     */
     public function testFunctionsWithGeoPointParamsDoNotThrow()
     {
         $params = ['key1' => new ParseGeoPoint(50, 50)];
-        $this->setExpectedException('Parse\ParseException', 'function not found');
+        $this->setExpectedException('Parse\ParseException',
+            'Invalid function: "unknown_function"');
         ParseCloud::run('unknown_function', $params);
     }
 
+    /**
+     * @group cloud-code
+     */
     public function testUnknownFunctionFailure()
     {
         $params = ['key1' => 'value1'];
-        $this->setExpectedException('Parse\ParseException', 'function not found');
+        $this->setExpectedException('Parse\ParseException',
+            'Invalid function: "unknown_function"');
         ParseCloud::run('unknown_function', $params);
     }
 }

--- a/tests/Parse/ParseCloudTest.php
+++ b/tests/Parse/ParseCloudTest.php
@@ -59,7 +59,7 @@ class ParseCloudTest extends \PHPUnit_Framework_TestCase
      * @group cloud-code
      */
     public function testFunctionCallException() {
-        $this->expectException('\Parse\ParseException',
+        $this->setExpectedException('\Parse\ParseException',
             'bad stuff happened');
 
         ParseCloud::run('bar', [

--- a/tests/Parse/ParseConfigTest.php
+++ b/tests/Parse/ParseConfigTest.php
@@ -2,12 +2,56 @@
 
 namespace Parse\Test;
 
+use Parse\ParseConfig;
+
 class ParseConfigTest extends \PHPUnit_Framework_TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        Helper::setUp();
+    }
+
+    /**
+     * @group parse-config
+     */
+    public function testDefaultConfig()
+    {
+        $config = new ParseConfig();
+        $this->assertEquals([], $config->getConfig());
+
+    }
+
+    /**
+     * @group parse-config
+     */
     public function testGetConfig()
     {
         $config = new ConfigMock();
         $this->assertEquals('bar', $config->get('foo'));
         $this->assertEquals(1, $config->get('some'));
+
+        // check null value
+        $this->assertNull($config->get('notakey'));
+
+        // check html value
+        $this->assertEquals('<value>', $config->get('another'));
+
+    }
+
+    /**
+     * @group parse-config
+     */
+    public function testEscapeConfig() {
+        $config = new ConfigMock();
+
+        // check html encoded value
+        $this->assertEquals('&lt;value&gt;', $config->escape('another'));
+
+        // check null value
+        $this->assertNull($config->escape('notakey'));
+
+        // check normal value
+        $this->assertEquals('bar', $config->escape('foo'));
+
     }
 }

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -2,6 +2,7 @@
 
 namespace Parse\Test;
 
+use Parse\ParseException;
 use Parse\ParseFile;
 use Parse\ParseObject;
 use Parse\ParseQuery;
@@ -24,7 +25,7 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
         $file = ParseFile::_createFromServer('hi.txt', 'http://');
         $file2 = ParseFile::createFromData('hello', 'hi.txt');
         $file3 = ParseFile::createFromFile(
-            'ParseFileTest.php',
+            APPLICATION_PATH.'/tests/Parse/ParseFileTest.php',
             'file.php'
         );
         $this->assertEquals('http://', $file->getURL());
@@ -58,6 +59,45 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @group file-download-test
+     */
+    public function testParseFileDownloadUnsaved()
+    {
+        $this->expectException('\Parse\ParseException',
+            'Cannot retrieve data for unsaved ParseFile.');
+        $file = ParseFile::createFromData(null, 'file.txt');
+        $file->getData();
+
+    }
+
+    /**
+     * @group file-download-test
+     */
+    public function testParsefileDeleteUnsaved()
+    {
+        $this->expectException('\Parse\ParseException',
+            'Cannot delete file that has not been saved.');
+        $file = ParseFile::createFromData('a test file', 'file.txt');
+        $file->delete();
+
+    }
+
+    /**
+     * @group file-download-test
+     */
+    public function testParseFileDownloadBadURL()
+    {
+        $this->expectException('\Parse\ParseException',
+            'Cannot delete file that has not been saved.');
+        $file = ParseFile::_createFromServer('file.txt', 'http://404.example.com');
+        $file->getData();
+
+    }
+
+    /**
+     * @group test-parsefile-round-trip
+     */
     public function testParseFileRoundTrip()
     {
         $contents = 'What would Bryan do?';
@@ -81,6 +121,11 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
         $file2->save();
         $file3->save();
 
+        // check initial mime types after creating from data
+        $this->assertEquals('unknown/unknown', $file->getMimeType());
+        $this->assertEquals('text/plain', $file2->getMimeType());
+        $this->assertEquals('image/png', $file3->getMimeType());
+
         $fileAgain = ParseFile::_createFromServer($file->getName(), $file->getURL());
         $file2Again = ParseFile::_createFromServer($file2->getName(), $file2->getURL());
         $file3Again = ParseFile::_createFromServer($file3->getName(), $file3->getURL());
@@ -89,8 +134,9 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($contents, $file2Again->getData());
         $this->assertEquals($contents, $file3Again->getData());
 
-        $this->assertEquals('unknown/unknown', $fileAgain->getMimeType());
-        $this->assertEquals('text/plain', $file2Again->getMimeType());
+        // check mime types after calling getData
+        $this->assertEquals('application/octet-stream', $fileAgain->getMimeType());
+        $this->assertEquals('image/png', $file2Again->getMimeType());
         $this->assertEquals('image/png', $file3Again->getMimeType());
     }
 

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -64,7 +64,7 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseFileDownloadUnsaved()
     {
-        $this->expectException('\Parse\ParseException',
+        $this->setExpectedException('\Parse\ParseException',
             'Cannot retrieve data for unsaved ParseFile.');
         $file = ParseFile::createFromData(null, 'file.txt');
         $file->getData();
@@ -76,7 +76,7 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testParsefileDeleteUnsaved()
     {
-        $this->expectException('\Parse\ParseException',
+        $this->setExpectedException('\Parse\ParseException',
             'Cannot delete file that has not been saved.');
         $file = ParseFile::createFromData('a test file', 'file.txt');
         $file->delete();
@@ -88,8 +88,7 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseFileDownloadBadURL()
     {
-        $this->expectException('\Parse\ParseException',
-            'Cannot delete file that has not been saved.');
+        $this->setExpectedException('\Parse\ParseException', '', 6);
         $file = ParseFile::_createFromServer('file.txt', 'http://404.example.com');
         $file->getData();
 

--- a/tests/Parse/ParseGeoBoxTest.php
+++ b/tests/Parse/ParseGeoBoxTest.php
@@ -24,6 +24,9 @@ class ParseGeoBoxTest extends \PHPUnit_Framework_TestCase
         Helper::tearDown();
     }
 
+    /**
+     * @group test-geo-box
+     */
     public function testGeoBox()
     {
         $caltrainStationLocation = new ParseGeoPoint(37.776346, -122.394218);
@@ -49,35 +52,56 @@ class ParseGeoBoxTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($objectsInSF));
         $this->assertEquals('caltrain', $objectsInSF[0]->get('name'));
 
-        // Switch order of args, should fail because it crosses the dateline
+        // Switch order of args
+        // (note) used to fail on old parse, passes in the open source variant
         $query = new ParseQuery('TestObject');
         $query->withinGeoBox('location', $northeastOfSF, $southwestOfSF);
+        $objectsInSF = $query->find();
+        $this->assertEquals(1, count($objectsInSF));
+        $this->assertEquals('caltrain', $objectsInSF[0]->get('name'));
+        // TODO remove
+        /* , should fail because it crosses the dateline
         try {
             $results = $query->find();
-            $this->assertTrue(false, 'Query should fail because it crosses dateline');
+            $this->assertTrue(false, 'Query should fail because it crosses dateline, with results:'.json_encode($results[0]));
         } catch (ParseException $e) {
         }
+        */
 
         $northwestOfSF = new ParseGeoPoint(37.822802, -122.526398);
         $southeastOfSF = new ParseGeoPoint(37.708813, -122.373962);
 
-        // Switch just longitude, should fail because it crosses the dateline
+        // Switch just longitude
+        // (note) used to fail on old parse, passes in the open source variant
         $query = new ParseQuery('TestObject');
         $query->withinGeoBox('location', $southeastOfSF, $northwestOfSF);
+        $objectsInSF = $query->find();
+        $this->assertEquals(1, count($objectsInSF));
+        $this->assertEquals('caltrain', $objectsInSF[0]->get('name'));
+        // TODO remove
+        /* , should fail because it crosses the dateline
         try {
             $query->find();
             $this->assertTrue(false, 'Query should fail because it crosses dateline');
         } catch (ParseException $e) {
         }
+        */
 
-        // Switch just the latitude, should fail because it doesnt make sense
+        // Switch just the latitude
+        // (note) used to fail on old parse, passes in the open source variant
         $query = new ParseQuery('TestObject');
         $query->withinGeoBox('location', $northwestOfSF, $southeastOfSF);
+        $objectsInSF = $query->find();
+        $this->assertEquals(1, count($objectsInSF));
+        $this->assertEquals('caltrain', $objectsInSF[0]->get('name'));
+        // TODO remove
+        /* , should fail because it doesnt make sense
         try {
             $query->find();
             $this->assertTrue(false, 'Query should fail because it makes no sense');
         } catch (ParseException $e) {
         }
+        */
     }
 
     public function testGeoBoxSmallNearDateLine()
@@ -117,14 +141,25 @@ class ParseGeoBoxTest extends \PHPUnit_Framework_TestCase
         $southwestOfDateLine = new ParseGeoPoint(-10, 170);
         $northeastOfDateLine = new ParseGeoPoint(10, -170);
 
+        // (note) used to fail on old parse, passes in the open source variant
         $query = new ParseQuery('TestObject');
         $query->withinGeoBox('location', $southwestOfDateLine, $northeastOfDateLine);
         $query->ascending('order');
+        $objects = $query->find();
+
+        // verify # of objects
+        $this->assertCount(2, $objects);
+
+        // verify order of objects
+        $this->assertEquals('far west', $objects[0]->get('name'));
+        $this->assertEquals('far east', $objects[1]->get('name'));
+        /* TODO REMOVE
         try {
             $query->find();
             $this->assertTrue(false, 'Query should fail for crossing the date line.');
         } catch (ParseException $e) {
         }
+        */
     }
 
     public function testGeoBoxTooLarge()
@@ -133,6 +168,7 @@ class ParseGeoBoxTest extends \PHPUnit_Framework_TestCase
         $center = ParseObject::create('TestObject');
 
         $center->set('location', $centerPoint);
+        $center->set('name', 'center');
         $center->save();
 
         $southwest = new ParseGeoPoint(-89, -179);
@@ -144,10 +180,15 @@ class ParseGeoBoxTest extends \PHPUnit_Framework_TestCase
         // two points.
         $query = new ParseQuery('TestObject');
         $query->withinGeoBox('location', $southwest, $northeast);
+        $points = $query->find();
+        $this->assertCount(1, $points);
+        $this->assertEquals('center', $points[0]->get('name'));
+        /* TODO REMOVE
         try {
             $query->find();
             $this->assertTrue(false, 'Query should fail for being too large.');
         } catch (ParseException $e) {
         }
+        */
     }
 }

--- a/tests/Parse/ParseGeoPointTest.php
+++ b/tests/Parse/ParseGeoPointTest.php
@@ -200,5 +200,20 @@ class ParseGeoPointTest extends \PHPUnit_Framework_TestCase
         $query->withinMiles('location', $point, 10.0);
         $results = $query->find();
         $this->assertEquals(0, count($results));
+
+    }
+
+    public function testBadLatitude() {
+        $this->expectException('\Parse\ParseException',
+            'Latitude must be within range [-90.0, 90.0]');
+        new ParseGeoPoint(-180, 32);
+
+    }
+
+    public function testBadLongitude() {
+        $this->expectException('\Parse\ParseException',
+            'Longitude must be within range [-180.0, 180.0]');
+        new ParseGeoPoint(32, -360);
+
     }
 }

--- a/tests/Parse/ParseGeoPointTest.php
+++ b/tests/Parse/ParseGeoPointTest.php
@@ -204,14 +204,14 @@ class ParseGeoPointTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testBadLatitude() {
-        $this->expectException('\Parse\ParseException',
+        $this->setExpectedException('\Parse\ParseException',
             'Latitude must be within range [-90.0, 90.0]');
         new ParseGeoPoint(-180, 32);
 
     }
 
     public function testBadLongitude() {
-        $this->expectException('\Parse\ParseException',
+        $this->setExpectedException('\Parse\ParseException',
             'Longitude must be within range [-180.0, 180.0]');
         new ParseGeoPoint(32, -360);
 

--- a/tests/Parse/ParseHooksTest.php
+++ b/tests/Parse/ParseHooksTest.php
@@ -38,9 +38,13 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
         self::$hooks->createFunction('baz', 'https://api.example.com/baz');
 
         $function = self::$hooks->fetchFunction('baz');
-        $this->assertEquals([['functionName' => 'baz', 'url' => 'https://api.example.com/baz']], $function);
+        $this->assertEquals([
+            'functionName' => 'baz',
+            'url' => 'https://api.example.com/baz'
+        ], $function);
 
         self::$hooks->deleteFunction('baz');
+
     }
 
     public function testSingleFunctionNotFound()
@@ -63,7 +67,10 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
     public function testCreateFunction()
     {
         $function = self::$hooks->createFunction('baz', 'https://api.example.com/baz');
-        $this->assertEquals(['functionName' => 'baz', 'url' => 'https://api.example.com/baz'], $function);
+        $this->assertEquals([
+            'functionName' => 'baz',
+            'url' => 'https://api.example.com/baz'
+        ], $function);
 
         self::$hooks->deleteFunction('baz');
     }
@@ -75,20 +82,34 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
         try {
             self::$hooks->createFunction('baz', 'https://api.example.com/baz');
         } catch (ParseException $ex) {
-            $this->assertEquals('a webhook with name: baz already exists', $ex->getMessage());
+            $this->assertEquals('function name: baz already exits',
+                $ex->getMessage());
         }
 
         self::$hooks->deleteFunction('baz');
     }
 
+    /**
+     * @group hook-create-trigger
+     */
     public function testCreateTrigger()
     {
         $trigger = self::$hooks->createTrigger('Game', 'beforeSave', 'https://api.example.com/Game/beforeSave');
+        // validate
         $this->assertEquals([
             'className'   => 'Game',
             'triggerName' => 'beforeSave',
             'url'         => 'https://api.example.com/Game/beforeSave',
         ], $trigger);
+
+        // fetch and revalidate
+        $trigger = self::$hooks->fetchTrigger('Game', 'beforeSave');
+        $this->assertEquals([
+            'className'   => 'Game',
+            'triggerName' => 'beforeSave',
+            'url'         => 'https://api.example.com/Game/beforeSave',
+        ], $trigger);
+
 
         self::$hooks->deleteTrigger('Game', 'beforeSave');
     }
@@ -101,7 +122,9 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
             self::$hooks->createTrigger('Game', 'beforeDelete', 'https://api.example.com/Game/beforeDelete');
             $this->fail();
         } catch (ParseException $ex) {
-            $this->assertEquals('beforeDelete trigger already exists for class Game as a webhook', $ex->getMessage());
+            $this->assertEquals('class Game already has trigger beforeDelete',
+                $ex->getMessage());
+
         }
 
         self::$hooks->deleteTrigger('Game', 'beforeDelete');
@@ -112,7 +135,10 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
         self::$hooks->createFunction('baz', 'https://api.example.com/baz');
 
         $edited_function = self::$hooks->editFunction('baz', 'https://api.example.com/_baz');
-        $this->assertEquals(['functionName' => 'baz', 'url' => 'https://api.example.com/_baz'], $edited_function);
+        $this->assertEquals([
+            'functionName' => 'baz',
+            'url' => 'https://api.example.com/_baz'
+        ], $edited_function);
 
         self::$hooks->deleteFunction('baz');
     }
@@ -145,5 +171,37 @@ class ParseHooksTest extends PHPUnit_Framework_TestCase
 
         $deleted_trigger = self::$hooks->deleteTrigger('Game', 'beforeSave');
         $this->assertEmpty($deleted_trigger);
+    }
+
+    /**
+     * @group hooks-fetch-functions
+     */
+    public function testFetchFunctions()
+    {
+        self::$hooks->createFunction('func1', 'http://example1.com');
+        self::$hooks->createFunction('func2', 'http://example2.com');
+        self::$hooks->createFunction('func3', 'http://example3.com');
+
+        $functions = self::$hooks->fetchFunctions();
+
+        $this->assertEquals([
+            [
+                'functionName'  => 'func1',
+                'url'           => 'http://example1.com'
+            ],
+            [
+                'functionName'  => 'func2',
+                'url'           => 'http://example2.com'
+            ],
+            [
+                'functionName'  => 'func3',
+                'url'           => 'http://example3.com'
+            ]
+        ], $functions);
+
+        self::$hooks->deleteFunction('func1');
+        self::$hooks->deleteFunction('func2');
+        self::$hooks->deleteFunction('func3');
+
     }
 }

--- a/tests/Parse/ParseMemoryStorageTest.php
+++ b/tests/Parse/ParseMemoryStorageTest.php
@@ -27,7 +27,7 @@ class ParseMemoryStorageTest extends \PHPUnit_Framework_TestCase
     public function testIsUsingDefaultStorage()
     {
         $this->assertTrue(
-            self::$parseStorage instanceof Parse\ParseMemoryStorage
+            self::$parseStorage instanceof \Parse\ParseMemoryStorage
         );
     }
 
@@ -63,5 +63,12 @@ class ParseMemoryStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $result['foo2']);
         $this->assertEquals('bar', $result['foo3']);
         $this->assertEquals(3, count($result));
+    }
+
+    public function testSave()
+    {
+        // does nothing
+        self::$parseStorage->save();
+
     }
 }

--- a/tests/Parse/ParseObjectMock.php
+++ b/tests/Parse/ParseObjectMock.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 1/29/17
+ * Time: 10:08 PM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\ParseObject;
+
+class ParseObjectMock extends ParseObject
+{
+
+}

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -3,8 +3,13 @@
 namespace Parse\Test;
 
 use Parse\Internal\SetOperation;
+use Parse\ParseACL;
+use Parse\ParseInstallation;
 use Parse\ParseObject;
 use Parse\ParseQuery;
+use Parse\ParseRole;
+use Parse\ParseSession;
+use Parse\ParseUser;
 
 class ParseObjectTest extends \PHPUnit_Framework_TestCase
 {
@@ -278,7 +283,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
     public function testInvalidClassName()
     {
         $obj = ParseObject::create('Foo^bar');
-        $this->setExpectedException('Parse\ParseException', 'bad characters in classname');
+        $this->setExpectedException('Parse\ParseException', 'schema class name does not revalidate');
         $obj->save();
     }
 
@@ -288,7 +293,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $obj->set('foo^bar', 'baz');
         $this->setExpectedException(
             'Parse\ParseException',
-            'invalid field name'
+            'Invalid field name: foo^bar.'
         );
         $obj->save();
     }
@@ -738,6 +743,13 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
     public function testDestroyAll()
     {
         Helper::clearClass('TestObject');
+
+        // log in
+        $user = new ParseUser();
+        $user->setUsername('username123');
+        $user->setPassword('password123');
+        $user->signUp();
+
         $o1 = ParseObject::create('TestObject');
         $o2 = ParseObject::create('TestObject');
         $o3 = ParseObject::create('TestObject');
@@ -746,6 +758,10 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $query = new ParseQuery('TestObject');
         $results = $query->find();
         $this->assertEquals(0, count($results));
+
+        ParseUser::logOut();
+        $user->destroy(true);
+
     }
 
     public function testEmptyArray()
@@ -948,8 +964,8 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
             $this->fail('Save should have failed.');
         } catch (\Parse\ParseAggregateException $ex) {
             $errors = $ex->getErrors();
-            $this->assertContains('invalid field name', $errors[0]['error']);
-            $this->assertContains('invalid field name', $errors[1]['error']);
+            $this->assertEquals('Invalid field name: fos^^co.', $errors[0]['error']);
+            $this->assertEquals('Invalid field name: fo^^mo.', $errors[1]['error']);
         }
     }
 
@@ -970,5 +986,368 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $results[0]->get('foo'));
         $this->assertEquals('bar', $results[1]->get('foo'));
         $this->assertEquals('bar', $results[2]->get('foo'));
+    }
+
+    public function testNoRegisteredSubclasses()
+    {
+        $this->expectException('\Exception',
+            'You must initialize the ParseClient using ParseClient::initialize '.
+            'and your Parse API keys before you can begin working with Objects.');
+        ParseUser::_unregisterSubclass();
+        ParseRole::_unregisterSubclass();
+        ParseInstallation::_unregisterSubclass();
+        ParseSession::_unregisterSubclass();
+
+        new ParseObject('TestClass');
+
+    }
+
+    public function testMissingClassName()
+    {
+        Helper::setUp();
+
+        $this->expectException('\Exception',
+            'You must specify a Parse class name or register the appropriate '.
+            'subclass when creating a new Object.    Use ParseObject::create to '.
+            'create a subclass object.');
+
+        new ParseObjectMock();
+
+    }
+
+    public function testSettingProperties()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->key = "value";
+
+        $this->assertEquals('value', $obj->get('key'));
+
+    }
+
+    public function testSettingProtectedProperty()
+    {
+        $this->expectException('\Exception',
+            'Protected field could not be set.');
+        $obj = new ParseObject('TestClass');
+        $obj->updatedAt = "value";
+
+    }
+
+    public function testGettingProperties()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->key = "value";
+        $this->assertEquals('value', $obj->key);
+
+    }
+
+    public function testNullValues()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->key1 = 'notnull';
+        $obj->key2 = null;
+
+        // verify key2 is present
+        $this->assertNull($obj->get('key2'));
+
+        $obj->save();
+        $obj->fetch();
+
+        // verify we still have key2 present
+        $this->assertNull($obj->get('key2'));
+
+        $obj->destroy();
+
+    }
+
+    public function testIsset()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->set('key', 'value');
+        $this->assertTrue(isset($obj->key), 'Failed on "value"');
+
+        $obj->set('key', 9);
+        $this->assertTrue(isset($obj->key), 'Failed on 9');
+
+        $obj->set('key', 0);
+        $this->assertTrue(isset($obj->key), 'Failed on 0');
+
+        $obj->set('key', false);
+        $this->assertTrue(isset($obj->key), 'Failed on false');
+
+        // null should return false
+        $obj->set('key', null);
+        $this->assertFalse(isset($obj->key), 'Failed on null');
+
+    }
+
+    public function testGetAllKeys()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->set('key1', 'value1');
+        $obj->set('key2', 'value2');
+        $obj->set('key3', 'value3');
+
+        $estimatedData = $obj->getAllKeys();
+
+        $this->assertEquals([
+            'key1'  => 'value1',
+            'key2'  => 'value2',
+            'key3'  => 'value3'
+        ], $estimatedData);
+
+    }
+
+    public function testDirtyChildren()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->set('key1', 'value1');
+        $obj->save();
+
+        $obj2 = new ParseObject('TestClass');
+        $obj2->set('key2', 'value2');
+
+        $this->assertFalse($obj->isDirty());
+
+        $obj->set('innerObject', $obj2);
+
+        $this->assertTrue($obj->isDirty());
+
+        $obj->destroy();
+
+    }
+
+    public function testSetNullKey()
+    {
+        $this->expectException('\Exception',
+            'key may not be null.');
+        $obj = new ParseObject('TestClass');
+        $obj->set(null, 'value');
+
+    }
+
+    public function testSetWithArrayValue()
+    {
+        $this->expectException(
+            '\Exception',
+            'Must use setArray() or setAssociativeArray() for this value.'
+        );
+        $obj = new ParseObject('TestClass');
+        $obj->set('key', ['is-an-array' => 'yes']);
+        
+    }
+
+    public function testSetArrayNullKey()
+    {
+        $this->expectException('\Exception',
+            'key may not be null.');
+        $obj = new ParseObject('TestClass');
+        $obj->setArray(null, ['is-an-array' => 'yes']);
+
+    }
+
+    public function testSetArrayWithNonArrayValue()
+    {
+        $this->expectException(
+            '\Exception',
+            'Must use set() for non-array values.'
+        );
+        $obj = new ParseObject('TestClass');
+        $obj->setArray('key', 'not-an-array');
+
+    }
+
+    public function testAsocSetArrayNullKey()
+    {
+        $this->expectException('\Exception',
+            'key may not be null.');
+        $obj = new ParseObject('TestClass');
+        $obj->setAssociativeArray(null, ['is-an-array' => 'yes']);
+
+    }
+
+    public function testAsocSetArrayWithNonArrayValue()
+    {
+        $this->expectException(
+            '\Exception',
+            'Must use set() for non-array values.'
+        );
+        $obj = new ParseObject('TestClass');
+        $obj->setAssociativeArray('key', 'not-an-array');
+
+    }
+
+    public function testRemovingNullKey()
+    {
+        $this->expectException(
+            '\Exception',
+            'key may not be null.'
+        );
+        $obj = new ParseObject('TestClass');
+        $obj->remove(null, 'value');
+
+    }
+
+    public function testRevert()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->set('key1', 'value1');
+        $obj->set('key2', 'value2');
+
+        $obj->revert();
+
+        $this->assertNull($obj->key1);
+        $this->assertNull($obj->key2);
+
+    }
+
+    public function testEmptyFetchAll()
+    {
+        $this->assertEmpty(ParseObject::fetchAll([]));
+
+    }
+
+    public function testFetchAllMixedClasses()
+    {
+        $this->expectException('\Parse\ParseException',
+            'All objects should be of the same class.');
+
+        $objs = [];
+        $objs[] = new ParseObject('TestClass1');
+        $objs[] = new ParseObject('TestClass2');
+
+        ParseObject::fetchAll($objs);
+
+    }
+
+    public function testFetchAllUnsavedWithoutId()
+    {
+        $this->expectException('\Parse\ParseException',
+            'All objects must have an ID.');
+
+        $objs = [];
+        $objs[] = new ParseObject('TestClass');
+        $objs[] = new ParseObject('TestClass');
+
+        ParseObject::fetchAll($objs);
+
+    }
+
+    public function testFetchAllUnsavedWithId()
+    {
+        $this->expectException('\Parse\ParseException',
+            'All objects must exist on the server.');
+
+        $objs = [];
+        $objs[] = new ParseObject('TestClass', 'objectid1');
+        $objs[] = new ParseObject('TestClass', 'objectid2');
+
+        ParseObject::fetchAll($objs);
+    }
+
+    public function testRevertingUnsavedChangesViaFetch()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->set('montymxb', 'phpguy');
+        $obj->save();
+
+        $obj->set('montymxb', 'luaguy');
+
+        $obj->fetch();
+
+        $this->assertEquals('phpguy', $obj->montymxb);
+
+        $obj->destroy();
+
+    }
+
+    public function testMergeFromServer()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->set('key', 'value');
+        $obj->save();
+
+        $obj->_mergeAfterFetch([
+            '__type'    => 'className',
+            'key'       => 'new value',
+            'ACL'       => [
+                'u1'        => [
+                    'write'     => false,
+                    'read'      => true
+                ]
+            ]
+        ]);
+
+        $this->assertNull($obj->get('__type'));
+        $this->assertEquals('new value', $obj->get('key'));
+
+        $obj->destroy();
+
+    }
+
+    public function testDestroyingUnsaved()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->destroy();
+
+    }
+
+    public function testEncodeWithArray()
+    {
+        $obj = new ParseObject('TestClass');
+        $obj->setArray('arraykey', ['value1','value2']);
+
+        $encoded = json_decode($obj->_encode(), true);
+        $this->assertEquals($encoded['arraykey'], ['value1','value2']);
+
+    }
+
+    public function testToPointerWithoutId()
+    {
+        $this->expectException('\Exception',
+            "Can't serialize an unsaved Parse.Object");
+        (new ParseObject('TestClass'))->_toPointer();
+
+    }
+
+    public function testGettingSharedACL()
+    {
+        $acl = new ParseACL();
+        $acl->_setShared(true);
+
+        $obj = new ParseObject('TestClass');
+        $obj->setACL($acl);
+
+        $copy = $obj->getACL();
+
+        $this->assertTrue($copy !== $acl);
+        $this->assertEquals($copy->_encode(), $acl->_encode());
+
+    }
+
+    public function testSubclassRegisterMissingParseClassName()
+    {
+        $this->expectException('\Exception',
+            'Cannot register a subclass that does not have a parseClassName');
+        ParseObjectMock::registerSubclass();
+
+    }
+
+    public function testGetRegisteredSubclass()
+    {
+        $subclass = ParseObject::getRegisteredSubclass('_User');
+        $this->assertEquals('Parse\ParseUser', $subclass);
+
+        $subclass = ParseObject::getRegisteredSubclass('Unknown');
+        $this->assertTrue($subclass instanceof ParseObject);
+        $this->assertEquals('Unknown', $subclass->getClassName());
+
+    }
+
+    public function testGettingQueryForUnregisteredSubclass()
+    {
+        $this->expectException('\Exception',
+            'Cannot create a query for an unregistered subclass.');
+        ParseObjectMock::query();
     }
 }

--- a/tests/Parse/ParsePushTest.php
+++ b/tests/Parse/ParsePushTest.php
@@ -19,7 +19,7 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testNoMasterKey() {
-        $this->expectException(ParseException::class);
+        $this->setExpectedException(ParseException::class);
 
         ParsePush::send(
             [
@@ -66,7 +66,7 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
 
     public function testNonQueryWhere()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'Where parameter for Parse Push must be of type ParseQuery');
         ParsePush::send(
             [
@@ -91,7 +91,7 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
 
     public function testExpirationTimeAndIntervalSet()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'Both expiration_time and expiration_interval can\'t be set.');
         ParsePush::send(
             [
@@ -112,7 +112,7 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
                 'channels' => [''],
                 'data'     => ['alert' => 'sample message'],
             ]
-        );
+        , true);
 
         $this->assertArrayHasKey('_headers', $response);
     }

--- a/tests/Parse/ParsePushTest.php
+++ b/tests/Parse/ParsePushTest.php
@@ -2,6 +2,7 @@
 
 namespace Parse\Test;
 
+use Parse\ParseException;
 use Parse\ParseInstallation;
 use Parse\ParsePush;
 
@@ -17,6 +18,17 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         Helper::tearDown();
     }
 
+    public function testNoMasterKey() {
+        $this->expectException(ParseException::class);
+
+        ParsePush::send(
+            [
+                'channels' => [''],
+                'data'     => ['alert' => 'sample message'],
+            ]
+        );
+    }
+
     public function testBasicPush()
     {
         ParsePush::send(
@@ -24,7 +36,7 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             'channels' => [''],
             'data'     => ['alert' => 'sample message'],
             ]
-        );
+        , true);
     }
 
     public function testPushToQuery()
@@ -36,7 +48,33 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             'data'  => ['alert' => 'iPhone 5 is out!'],
             'where' => $query,
             ]
-        );
+        , true);
+
+    }
+
+    public function testPushToQueryWithoutWhere()
+    {
+        $query = ParseInstallation::query();
+        ParsePush::send(
+            [
+                'data'  => ['alert' => 'Done without conditions!'],
+                'where' => $query,
+            ]
+            , true);
+
+    }
+
+    public function testNonQueryWhere()
+    {
+        $this->expectException(\Exception::class,
+            'Where parameter for Parse Push must be of type ParseQuery');
+        ParsePush::send(
+            [
+                'data'  => ['alert' => 'Will this really work?'],
+                'where' => 'not-a-query',
+            ]
+            , true);
+
     }
 
     public function testPushDates()
@@ -48,6 +86,22 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
             'expiration_time' => new \DateTime(),
             'channels'        => [],
             ]
-        );
+        , true);
+    }
+
+    public function testExpirationTimeAndIntervalSet()
+    {
+        $this->expectException(\Exception::class,
+            'Both expiration_time and expiration_interval can\'t be set.');
+        ParsePush::send(
+            [
+                'data'            => ['alert' => 'iPhone 5 is out!'],
+                'push_time'       => new \DateTime(),
+                'expiration_time' => new \DateTime(),
+                'expiration_interval'   => 90,
+                'channels'        => [],
+            ]
+            , true);
+
     }
 }

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -2090,7 +2090,7 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
 
     public function testOrQueriesVaryingClasses()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'All queries must be for the same class');
         ParseQuery::orQueries([
             new ParseQuery('Class1'),

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -3,8 +3,10 @@
 namespace Parse\Test;
 
 use Parse\ParseACL;
+use Parse\ParseException;
 use Parse\ParseObject;
 use Parse\ParseQuery;
+use Parse\ParseUser;
 
 class ParseQueryTest extends \PHPUnit_Framework_TestCase
 {
@@ -155,6 +157,25 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testEndsWithSingle()
+    {
+        $this->provideTestObjects(10);
+        $query = new ParseQuery('TestObject');
+        $query->endsWith('foo', 'r0');
+        $results = $query->find();
+        $this->assertEquals(
+            count($results),
+            1,
+            'EndsWith function did not return correct number of objects.'
+        );
+        $this->assertEquals(
+            $results[0]->get('foo'),
+            'bar0',
+            'EndsWith function did not return the correct object.'
+        );
+
+    }
+
     public function testStartsWithSingle()
     {
         $this->provideTestObjects(10);
@@ -188,6 +209,14 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
 
     public function testStartsWithMiddle()
     {
+
+        $user = ParseUser::getCurrentUser();
+
+        if(isset($user)) {
+            throw new ParseException($user->_encode());
+
+        }
+
         $this->provideTestObjects(10);
         $query = new ParseQuery('TestObject');
         $query->startsWith('foo', 'ar');
@@ -424,7 +453,7 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
     public function testFindWithError()
     {
         $query = new ParseQuery('TestObject');
-        $this->setExpectedException('Parse\ParseException', 'Invalid key', 102);
+        $this->setExpectedException('Parse\ParseException', 'Invalid key name: $foo', 105);
         $query->equalTo('$foo', 'bar');
         $query->find();
     }
@@ -487,7 +516,7 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
     {
         $query = new ParseQuery('TestObject');
         $query->equalTo('$foo', 'bar');
-        $this->setExpectedException('Parse\ParseException', 'Invalid key', 102);
+        $this->setExpectedException('Parse\ParseException', 'Invalid key name: $foo', 105);
         $query->first();
     }
 
@@ -638,7 +667,7 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
     {
         $query = new ParseQuery('Test');
         $query->equalTo('$foo', 'bar');
-        $this->setExpectedException('Parse\ParseException', 'Invalid key', 102);
+        $this->setExpectedException('Parse\ParseException', 'Invalid key name: $foo', 105);
         $query->count();
     }
 
@@ -1452,6 +1481,10 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @throws ParseException
+     * @group order-by-updated-at-desc
+     */
     public function testOrderByUpdatedAtDesc()
     {
         $numbers = [3, 1, 2];
@@ -1476,7 +1509,7 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
             count($results),
             'Did not return correct number of objects.'
         );
-        $expected = [4, 2, 3];
+        $expected = [4, 3, 2];
         for ($i = 0; $i < 3; ++$i) {
             $this->assertEquals(
                 $expected[$i],
@@ -1802,7 +1835,6 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
 
         $query = new ParseQuery('Parent');
         $query->includeKey('foo');
-        $this->setExpectedException('Parse\ParseException', '', 102);
         $results = $query->find();
         $this->assertEquals(
             1,
@@ -2026,5 +2058,44 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $count);
         $count = $query->count(true);
         $this->assertEquals(1, $count);
+    }
+
+    public function testAscendingByArray() {
+        $obj = new ParseObject('TestObject');
+        $obj->set('name', 'John');
+        $obj->set('country', 'US');
+        $obj->save();
+
+        $obj = new ParseObject('TestObject');
+        $obj->set('name', 'Bob');
+        $obj->set('country', 'US');
+        $obj->save();
+
+        $obj = new ParseObject('TestObject');
+        $obj->set('name', 'Joel');
+        $obj->set('country', 'CA');
+        $obj->save();
+
+        $query = new ParseQuery('TestObject');
+        $query->ascending(['country','name']);
+        $results = $query->find();
+
+        $this->assertEquals(3, count($results));
+
+        $this->assertEquals('Joel', $results[0]->name);
+        $this->assertEquals('Bob', $results[1]->name);
+        $this->assertEquals('John', $results[2]->name);
+
+    }
+
+    public function testOrQueriesVaryingClasses()
+    {
+        $this->expectException(\Exception::class,
+            'All queries must be for the same class');
+        ParseQuery::orQueries([
+            new ParseQuery('Class1'),
+            new ParseQuery('Class2')
+        ]);
+
     }
 }

--- a/tests/Parse/ParseRelationOperationTest.php
+++ b/tests/Parse/ParseRelationOperationTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 1/30/17
+ * Time: 11:07 AM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\Internal\ParseRelationOperation;
+use Parse\ParseObject;
+use Parse\ParseRelation;
+
+class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Helper::setUp();
+    }
+
+    public function tearDown()
+    {
+        Helper::clearClass('Class1');
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testMissingObjects()
+    {
+        $this->expectException(\Exception::class,
+            'Cannot create a ParseRelationOperation with no objects.');
+        new ParseRelationOperation(null, null);
+
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testMixedClasses()
+    {
+        $this->expectException(\Exception::class,
+            'All objects in a relation must be of the same class.');
+
+        $objects = [];
+        $objects[] = new ParseObject('Class1');
+        $objects[] = new ParseObject('Class2');
+
+        new ParseRelationOperation($objects, null);
+
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testSingleObjects()
+    {
+        $addObj = new ParseObject('Class1');
+        $addObj->save();
+        $delObj = new ParseObject('Class1');
+        $delObj->save();
+
+        $op = new ParseRelationOperation($addObj, $delObj);
+
+        $encoded = $op->_encode();
+
+        $this->assertEquals('AddRelation' ,$encoded['ops'][0]['__op']);
+        $this->assertEquals('RemoveRelation' ,$encoded['ops'][1]['__op']);
+
+        ParseObject::destroyAll([$addObj, $delObj]);
+
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testApplyDifferentClassRelation()
+    {
+        $this->expectException(\Exception::class,
+            'Related object object must be of class '
+            .'Class1, but Different_Class'
+            .' was passed in.');
+
+        // create one op
+        $addObj = new ParseObject('Class1');
+        $relOp1 = new ParseRelationOperation($addObj, null);
+
+        $relOp1->_apply(new ParseRelation(null, null, 'DifferentClass'), null, null);
+
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testInvalidApply()
+    {
+        $this->expectException(\Exception::class,
+            'Operation is invalid after previous operation.');
+        $addObj = new ParseObject('Class1');
+        $op = new ParseRelationOperation($addObj, null);
+        $op->_apply('bad value', null, null);
+
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testMergeNone()
+    {
+        $addObj = new ParseObject('Class1');
+        $op = new ParseRelationOperation($addObj, null);
+        $this->assertEquals($op, $op->_mergeWithPrevious(null));
+
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testMergeDifferentClass()
+    {
+        $this->expectException(\Exception::class,
+            'Related object object must be of class '
+            .'Class1, but AnotherClass'
+            .' was passed in.');
+
+        $addObj = new ParseObject('Class1');
+        $op = new ParseRelationOperation($addObj, null);
+
+        $diffObj = new ParseObject('AnotherClass');
+        $mergeOp = new ParseRelationOperation($diffObj, null);
+
+        $this->assertEquals($op, $op->_mergeWithPrevious($mergeOp));
+
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testInvalidMerge()
+    {
+        $this->expectException(\Exception::class,
+            'Operation is invalid after previous operation.');
+        $obj = new ParseObject('Class1');
+        $op = new ParseRelationOperation($obj, null);
+        $op->_mergeWithPrevious('not a relational op');
+
+    }
+
+    /**
+     * @group parse-relation-op
+     */
+    public function testRemoveElementsFromArray()
+    {
+        // test without passing an array
+        $array = [
+          'removeThis'
+        ];
+        ParseRelationOperation::removeElementsFromArray('removeThis', $array);
+
+        $this->assertEmpty($array);
+
+    }
+}

--- a/tests/Parse/ParseRelationOperationTest.php
+++ b/tests/Parse/ParseRelationOperationTest.php
@@ -30,7 +30,7 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingObjects()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'Cannot create a ParseRelationOperation with no objects.');
         new ParseRelationOperation(null, null);
 
@@ -41,7 +41,7 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMixedClasses()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'All objects in a relation must be of the same class.');
 
         $objects = [];
@@ -78,9 +78,9 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testApplyDifferentClassRelation()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'Related object object must be of class '
-            .'Class1, but Different_Class'
+            .'Class1, but DifferentClass'
             .' was passed in.');
 
         // create one op
@@ -96,7 +96,7 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidApply()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'Operation is invalid after previous operation.');
         $addObj = new ParseObject('Class1');
         $op = new ParseRelationOperation($addObj, null);
@@ -120,7 +120,7 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMergeDifferentClass()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'Related object object must be of class '
             .'Class1, but AnotherClass'
             .' was passed in.');
@@ -140,7 +140,7 @@ class ParseRelationOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->expectException(\Exception::class,
+        $this->setExpectedException(\Exception::class,
             'Operation is invalid after previous operation.');
         $obj = new ParseObject('Class1');
         $op = new ParseRelationOperation($obj, null);

--- a/tests/Parse/ParseRelationTest.php
+++ b/tests/Parse/ParseRelationTest.php
@@ -144,4 +144,48 @@ class ParseRelationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($results));
         $this->assertEquals($results[0]->getObjectId(), $parent2->getObjectId());
     }
+
+    /**
+     * @group relation-parent-set
+     */
+    public function testSwitchingParent()
+    {
+        // setup parent 1
+        $parent1 = new ParseObject('ParentObject');
+        $relation = $parent1->getRelation('children');
+
+        $child1 = new ParseObject('ChildObject');
+        $child1->set('name', 'child1');
+        $child1->save();
+
+        $child2 = new ParseObject('ChildObject');
+        $child2->set('name', 'child2');
+        $child2->save();
+        $relation->add([$child1, $child2]);
+        $parent1->save();
+
+        // setup parent 2
+        $parent2 = new ParseObject('ParentObject');
+        $relation = $parent2->getRelation('children');
+
+        $child = new ParseObject('ChildObject');
+        $child->set('name', 'child3');
+        $child->save();
+        $relation->add([$child]);
+        $parent2->save();
+
+        // get relation for parent one
+        $relation = $parent1->getRelation('children');
+
+        // switch parent to parent 2
+        $relation->setParent($parent2);
+
+        // get query for parent 2 instead now
+        $query = $relation->getQuery();
+        $children = $query->find();
+
+        $this->assertEquals(1, count($children));
+        $this->assertEquals('child3', $children[0]->get('name'));
+
+    }
 }

--- a/tests/Parse/ParseRoleTest.php
+++ b/tests/Parse/ParseRoleTest.php
@@ -232,7 +232,7 @@ class ParseRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testSettingNonStringAsName()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             "A role's name must be a string.");
         $role = new ParseRole();
         $role->setName(12345);
@@ -244,7 +244,7 @@ class ParseRoleTest extends \PHPUnit_Framework_TestCase
      */
     public function testSavingWithoutName()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Roles must have a name.');
         $role = new ParseRole();
         $role->setACL(new ParseACL());

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -302,7 +302,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSchemaGet()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Empty reply from server');
 
         $user = new ParseUser();
@@ -320,7 +320,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSchemaSave()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Empty reply from server');
 
         $user = new ParseUser();
@@ -338,7 +338,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSchemaUpdate()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Empty reply from server');
 
         $user = new ParseUser();
@@ -356,7 +356,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSchemaDelete()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Empty reply from server');
 
         $user = new ParseUser();

--- a/tests/Parse/ParseSessionStorageAltTest.php
+++ b/tests/Parse/ParseSessionStorageAltTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 1/30/17
+ * Time: 12:26 AM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\ParseException;
+use Parse\ParseSessionStorage;
+
+class ParseSessionStorageAltTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group session-storage-not-active
+     */
+    public function testNoSessionActive()
+    {
+        $this->expectException(ParseException::class,
+            'PHP session_start() must be called first.');
+        new ParseSessionStorage();
+
+    }
+}

--- a/tests/Parse/ParseSessionStorageAltTest.php
+++ b/tests/Parse/ParseSessionStorageAltTest.php
@@ -19,7 +19,7 @@ class ParseSessionStorageAltTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoSessionActive()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'PHP session_start() must be called first.');
         new ParseSessionStorage();
 

--- a/tests/Parse/ParseSessionStorageTest.php
+++ b/tests/Parse/ParseSessionStorageTest.php
@@ -15,6 +15,16 @@ class ParseSessionStorageTest extends \PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         ParseClient::_unsetStorage();
+
+        // indicate we should not use cookies
+        ini_set("session.use_cookies", 0);
+        // indicate we can use something other than cookies
+        ini_set("session.use_only_cookies", 0);
+        // enable transparent sid support, for url based sessions
+        ini_set("session.use_trans_sid", 1);
+        // clear cache control for session pages
+        ini_set("session.cache_limiter", "");
+
         session_start();
         Helper::setUp();
         self::$parseStorage = ParseClient::getStorage();
@@ -33,7 +43,7 @@ class ParseSessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testIsUsingParseSession()
     {
-        $this->assertTrue(self::$parseStorage instanceof Parse\ParseSessionStorage);
+        $this->assertTrue(self::$parseStorage instanceof \Parse\ParseSessionStorage);
     }
 
     public function testSetAndGet()
@@ -68,5 +78,27 @@ class ParseSessionStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $result['foo2']);
         $this->assertEquals('bar', $result['foo3']);
         $this->assertEquals(3, count($result));
+    }
+
+    public function testSave()
+    {
+        // does nothing
+        self::$parseStorage->save();
+
+    }
+
+    /**
+     * @group session-recreate-storage
+     */
+    public function testRecreatingSessionStorage()
+    {
+        unset($_SESSION['parseData']);
+
+        $this->assertFalse(isset($_SESSION['parseData']));
+
+        new ParseSessionStorage();
+
+        $this->assertEmpty($_SESSION['parseData']);
+
     }
 }

--- a/tests/Parse/ParseSessionTest.php
+++ b/tests/Parse/ParseSessionTest.php
@@ -3,6 +3,7 @@
 namespace Parse\Test;
 
 use Parse\ParseClient;
+use Parse\ParseException;
 use Parse\ParseSession;
 use Parse\ParseUser;
 
@@ -41,6 +42,8 @@ class ParseSessionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($session->isCurrentSessionRevocable());
 
         ParseUser::logOut();
+
+        $this->assertNull(ParseSession::isCurrentSessionRevocable());
 
         ParseUser::logIn('username', 'password');
         $session = ParseSession::getCurrentSession();

--- a/tests/Parse/RemoveOperationTest.php
+++ b/tests/Parse/RemoveOperationTest.php
@@ -22,7 +22,7 @@ class RemoveOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingArray()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'RemoveOperation requires an array.');
         new RemoveOperation('not an array');
 
@@ -65,7 +65,7 @@ class RemoveOperationTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidMerge()
     {
-        $this->expectException(ParseException::class,
+        $this->setExpectedException(ParseException::class,
             'Operation is invalid after previous operation.');
         $removeOp = new RemoveOperation([
             'key1'          => 'value1'

--- a/tests/Parse/RemoveOperationTest.php
+++ b/tests/Parse/RemoveOperationTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 1/30/17
+ * Time: 12:05 PM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\Internal\AddOperation;
+use Parse\Internal\DeleteOperation;
+use Parse\Internal\RemoveOperation;
+use Parse\Internal\SetOperation;
+use Parse\ParseException;
+
+class RemoveOperationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group remove-op
+     */
+    public function testMissingArray()
+    {
+        $this->expectException(ParseException::class,
+            'RemoveOperation requires an array.');
+        new RemoveOperation('not an array');
+
+    }
+
+    /**
+     * @group remove-op-merge
+     */
+    public function testMergePrevious()
+    {
+        $removeOp = new RemoveOperation([
+            'key1'          => 'value1'
+        ]);
+
+        $this->assertEquals($removeOp, $removeOp->_mergeWithPrevious(null));
+
+        // check delete op
+        $merged = $removeOp->_mergeWithPrevious(new DeleteOperation());
+        $this->assertTrue($merged instanceof DeleteOperation);
+
+        // check set op
+        $merged = $removeOp->_mergeWithPrevious(new SetOperation('newvalue'));
+        $this->assertTrue($merged instanceof SetOperation);
+        $this->assertEquals([
+            'newvalue'
+        ], $merged->getValue(), 'Value was not as expected');
+
+        // check self
+        $merged = $removeOp->_mergeWithPrevious(new RemoveOperation(['key2'   => 'value2']));
+        $this->assertTrue($merged instanceof RemoveOperation);
+        $this->assertEquals([
+            'key2'  => 'value2',
+            'key1'  => 'value1'
+        ], $merged->getValue(), 'Value was not as expected');
+
+    }
+
+    /**
+     * @group remove-op
+     */
+    public function testInvalidMerge()
+    {
+        $this->expectException(ParseException::class,
+            'Operation is invalid after previous operation.');
+        $removeOp = new RemoveOperation([
+            'key1'          => 'value1'
+        ]);
+        $removeOp->_mergeWithPrevious(new AddOperation(['key'=>'value']));
+
+    }
+
+    /**
+     * @group remove-op
+     */
+    public function testEmptyApply()
+    {
+        $removeOp = new RemoveOperation([
+            'key1'          => 'value1'
+        ]);
+        $this->assertEmpty($removeOp->_apply([], null, null));
+
+    }
+}


### PR DESCRIPTION
This fixes and updates the test suite in order to ensure compatibility with the open source Parse Server. Puts code coverage at around 95%, helping to ensure the consistency and integrity of the project through future versions. Includes changes to the SDK to facilitate testing and to ensure proper operation in conjunction with the open source parse server. A few syntax errors were patched to top it off.

Also updates CONTRIBUTING.md with a new testing setup for the open source parse server, as well as instructions on how to configure and maintain a proper testing environment.