### PR TITLE
Added ParsePushStatus class and updated tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After including the required files from the SDK, you need to initalize the Parse
 ```php
 ParseClient::initialize( $app_id, $rest_key, $master_key );
 // Users of Parse Server will need to point ParseClient at their remote URL and Mount Point:
-ParseClient::setServerURL('https://my-parse-server.com','parse');
+ParseClient::setServerURL('https://my-parse-server.com:port','parse');
 ```
 
 If your server does not use or require a REST key you may initialize the ParseClient as follows, safely omitting the REST key:
@@ -53,8 +53,15 @@ If your server does not use or require a REST key you may initialize the ParseCl
 ```php
 ParseClient::initialize( $app_id, null, $master_key );
 // Users of Parse Server will need to point ParseClient at their remote URL and Mount Point:
-ParseClient::setServerURL('https://my-parse-server.com','parse');
+ParseClient::setServerURL('https://my-parse-server.com:port','parse');
 ```
+
+Notice
+Parse server's default port is `1337` and the second parameter `parse` is the route prefix of your parse server.
+
+For example if your parse server's url is `http://example.com:1337/parse` then you can set the server url using the following snippet
+
+`ParseClient::setServerURL('https://example.com:1337','parse');`
 
 Usage
 -----
@@ -224,10 +231,33 @@ ParsePush::send(array(
     "data" => $data
 ), true);
 
-// Get Push Status Id
-$reponse = ParsePush::send($data, true);
-if(isset($response['_headers']['X-Push-Status-Id'])) {
-    // Retrieve info on _PushStatus using the id
+// Get Push Status
+$response = ParsePush::send($data, true);
+if(ParsePush::hasStatus($response)) {
+
+    // Retrieve PushStatus object
+    $pushStatus = ParsePush::getStatus($response);
+    
+    // get push status string
+    $status = $pushStatus->getPushStatus();
+    
+    if($status == "succeeded") {
+        // handle a successful push request
+        
+    } else if($status == "running") {
+        // handle a running push request
+        
+    } else if($status == "failed") {
+        // push request did not succeed
+        
+    }
+    
+    // get # pushes sent
+    $sent = $pushStatus->getPushesSent();
+    
+    // get # pushes failed
+    $failed = $pushStatus->getPushesFailed();
+    
 }
 ```
 

--- a/src/Parse/ParseClient.php
+++ b/src/Parse/ParseClient.php
@@ -122,6 +122,10 @@ final class ParseClient
             ParseInstallation::registerSubclass();
         }
 
+        if(!ParseObject::hasRegisteredSubclass('_PushStatus')) {
+            ParsePushStatus::registerSubclass();
+        }
+
         ParseSession::registerSubclass();
         self::$applicationId = $app_id;
         self::$restKey = $rest_key;

--- a/src/Parse/ParsePush.php
+++ b/src/Parse/ParsePush.php
@@ -77,4 +77,50 @@ class ParsePush
             true
         );
     }
+
+    /**
+     * Returns whether or not the given response has a push status
+     * Checks to see if X-Push-Status-Id is present in $response
+     *
+     * @param array $response    Response from ParsePush::send
+     * @return bool
+     */
+    public static function hasStatus($response)
+    {
+        return(
+            isset($response['_headers']) &&
+            isset($response['_headers']['X-Parse-Push-Status-Id'])
+        );
+
+    }
+
+    /**
+     * Returns the PushStatus for a response from ParsePush::send
+     *
+     * @param array $response   Response from ParsePush::send
+     * @return null|ParsePushStatus
+     */
+    public static function getStatus($response)
+    {
+        if(!isset($response['_headers'])) {
+            // missing headers
+            return null;
+
+        }
+
+        $headers = $response['_headers'];
+
+        if(!isset($headers['X-Parse-Push-Status-Id'])) {
+            // missing push status id
+            return null;
+
+        }
+
+        // get our push status id
+        $pushStatusId = $response['_headers']['X-Parse-Push-Status-Id'];
+
+        // return our push status if it exists
+        return ParsePushStatus::getFromId($pushStatusId);
+
+    }
 }

--- a/src/Parse/ParsePushStatus.php
+++ b/src/Parse/ParsePushStatus.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Parse;
+
+/**
+ * ParsePushStatus - Representation of PushStatus for push notifications
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ */
+class ParsePushStatus extends ParseObject
+{
+    public static $parseClassName = '_PushStatus';
+
+    /**
+     * Returns a push status object or null from an id
+     *
+     * @param string $id    Id to get this push status by
+     * @return ParsePushStatus|null
+     */
+    public static function getFromId($id)
+    {
+        try {
+            // return the associated PushStatus object
+            $query = new ParseQuery(self::$parseClassName);
+            return $query->get($id, true);
+
+        } catch (ParseException $pe) {
+            // no push found
+            return null;
+
+        }
+
+    }
+
+    /**
+     * Gets the time this push was sent at
+     *
+     * @return \DateTime
+     */
+    public function getPushTime()
+    {
+        return new \DateTime($this->get("pushTime"));
+
+    }
+
+    /**
+     * Gets the query used to send this push
+     *
+     * @return ParseQuery
+     */
+    public function getPushQuery()
+    {
+        $query = $this->get("query");
+
+        // get the conditions
+        $queryConditions = json_decode($query, true);
+
+        // setup a query
+        $query = new ParseQuery(self::$parseClassName);
+
+        // set the conditions
+        $query->_setConditions($queryConditions);
+
+        return $query;
+
+    }
+
+    /**
+     * Gets the payload
+     *
+     * @return array
+     */
+    public function getPushPayload()
+    {
+        return json_decode($this->get("payload"), true);
+
+    }
+
+    /**
+     * Gets the source of this push
+     *
+     * @return string
+     */
+    public function getPushSource()
+    {
+        return $this->get("source");
+
+    }
+
+    /**
+     * Gets the status of this push
+     *
+     * @return string
+     */
+    public function getPushStatus()
+    {
+        return $this->get("status");
+
+    }
+
+    /**
+     * Gets the number of pushes sent
+     *
+     * @return int
+     */
+    public function getPushesSent()
+    {
+        return $this->get("numSent");
+
+    }
+
+    /**
+     * Gets the hash for this push
+     *
+     * @return string
+     */
+    public function getPushHash()
+    {
+        return $this->get("pushHash");
+
+    }
+
+    /**
+     * Gets the number of pushes failed
+     *
+     * @return int
+     */
+    public function getPushesFailed()
+    {
+        return $this->get("numFailed");
+
+    }
+}

--- a/src/Parse/ParseQuery.php
+++ b/src/Parse/ParseQuery.php
@@ -135,6 +135,30 @@ class ParseQuery
     }
 
     /**
+     * Sets the conditions of this parse query from an array
+     *
+     * @param array $conditions Array of Conditions to set
+     * @throws ParseException
+     */
+    public function _setConditions($conditions)
+    {
+        if(!is_array($conditions)) {
+            throw new ParseException("Conditions must be in an array");
+
+        }
+
+        // iterate over and add each condition
+        foreach($conditions as $key => $entry) {
+            foreach($entry as $condition => $value) {
+                $this->addCondition($key, $condition, $value);
+
+            }
+
+        }
+
+    }
+
+    /**
      * Add a constraint to the query that requires a particular key's value to
      * be not equal to the provided value.
      *

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -6,6 +6,7 @@ use Parse\Internal\SetOperation;
 use Parse\ParseACL;
 use Parse\ParseInstallation;
 use Parse\ParseObject;
+use Parse\ParsePushStatus;
 use Parse\ParseQuery;
 use Parse\ParseRole;
 use Parse\ParseSession;
@@ -997,6 +998,7 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         ParseRole::_unregisterSubclass();
         ParseInstallation::_unregisterSubclass();
         ParseSession::_unregisterSubclass();
+        ParsePushStatus::_unregisterSubclass();
 
         new ParseObject('TestClass');
 

--- a/tests/Parse/ParseQueryTest.php
+++ b/tests/Parse/ParseQueryTest.php
@@ -2098,4 +2098,35 @@ class ParseQueryTest extends \PHPUnit_Framework_TestCase
         ]);
 
     }
+
+    /**
+     * @group query-set-conditions
+     */
+    public function testSetConditions()
+    {
+        $query = new ParseQuery('TestObject');
+        $query->_setConditions([
+            [
+                'key'  => 'value'
+            ]
+        ]);
+
+        $this->assertEquals([
+            'where' => [
+                [
+                    'key'   => 'value'
+                ]
+            ]
+        ], $query->_getOptions());
+    }
+
+    public function testBadConditions()
+    {
+        $this->setExpectedException(ParseException::class,
+            "Conditions must be in an array");
+
+        $query = new ParseQuery('TestObject');
+        $query->_setConditions('not-an-array');
+
+    }
 }


### PR DESCRIPTION
ParseServer supports returning an ```_PushStatus``` object id and the php sdk supports retrieving this value via headers returned from ```ParsePush::send```. However handling the _PushStatus instance is up to the developer. 

This PR adds a ```ParsePushStatus``` class which provides an abstracted means of retrieving this object and of reading it's subsequent values.

Since not _all_ parse server instances have this capability it is up to the developer to check if the ```X-Push-Status-Id``` is returned in the headers from ```ParsePush::send```, which can be used to retrieve the _PushStatus instance and get data as follows: 
```php
$reponse = ParsePush::send(array(
    "channels" => ["PushFans"],
    "data" => array(
        "alert" => "Hello World!"
    )
), true);
if(isset($response['_headers']['X-Push-Status-Id'])) {
     // Retrieve PushStatus object
    $pushStatusId = $response['_headers']['X-Push-Status-Id'];
    $pushStatus = ParsePushStatus::getFromId($pushStatusId);

   // get push status string
    $status = $pushStatus->getPushStatus();
    
    if($status == "succeeded") {
        // handle a successful push request
        
    } else {
        // push request did not succeed
        
    }
    
    // get # pushes sent
    $sent = $pushStatus->getPushesSent();
    
    // get # pushes failed
    $failed = $pushStatus->getPushesFailed();

}
```
The reference above has been added to the README.md in this PR.

Updated ParseQuery to allow setting of conditions from an array. _PushStatus returns a json of conditions for the query array, this allows us to recreate the sending query. Additionally new test cases have been added for all added functionality.