### PR TITLE
Updated with requirement of 'where' or 'query' in ParsePush

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,14 +213,17 @@ Push:
 ```php
 $data = array("alert" => "Hi!");
 
-// Parse Server requires the master key for sending push.  Pass true as the second parameter.
-ParsePush::send($data, true);
+// Parse Server has a few requirements:
+// - The master key is required for sending pushes, pass true as the second parameter
+// - You must set your recipients by using 'channels' or 'where', but you must not pass both
+
 
 // Push to Channels
 ParsePush::send(array(
     "channels" => ["PHPFans"],
     "data" => $data
 ), true);
+
 
 // Push to Query
 $query = ParseInstallation::query();
@@ -231,8 +234,13 @@ ParsePush::send(array(
     "data" => $data
 ), true);
 
+
 // Get Push Status
-$response = ParsePush::send($data, true);
+$response = ParsePush::send(array(
+    "channels" => ["StatusFans"],
+    "data" => $data
+), true);
+
 if(ParsePush::hasStatus($response)) {
 
     // Retrieve PushStatus object

--- a/tests/Parse/ParsePushTest.php
+++ b/tests/Parse/ParsePushTest.php
@@ -41,6 +41,46 @@ class ParsePushTest extends \PHPUnit_Framework_TestCase
         , true);
     }
 
+    /**
+     * @group parse-push
+     */
+    public function testMissingWhereAndChannels()
+    {
+        $this->setExpectedException(ParseException::class,
+            "Sending a push requires either \"channels\" or a \"where\" query.");
+
+        ParsePush::send([
+            'data'  => [
+                'alert' => 'are we missing something?'
+            ]
+        ], true);
+
+    }
+
+    /**
+     * @group parse-push
+     */
+    public function testWhereAndChannels()
+    {
+        $this->setExpectedException(ParseException::class,
+            "Channels and query can not be set at the same time.");
+
+        $query = ParseInstallation::query();
+        $query->equalTo('key', 'value');
+
+        ParsePush::send([
+            'data'      => [
+                'alert'     => 'too many limits'
+            ],
+            'channels'  => [
+                'PushFans',
+                'PHPFans'
+            ],
+            'where'     => $query
+        ], true);
+
+    }
+
     public function testPushToQuery()
     {
         $query = ParseInstallation::query();


### PR DESCRIPTION
Parse Server requires that, for ParsePush, you must set recipients via 'channels' or 'where'. However you may not use both. 

This updates the README.md references to properly adhere to this and to caution against it as well. Adds tests to expect exceptions when passing neither of these or both, as either case will cause an exception to be thrown.