### PR TITLE
Added mention that Parse Server must be configured to use Push

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ $file = ParseFile::createFromData($contents, "Parse.txt", "text/plain");
 
 Push:
 
+In order to use Push you must first configure a [working push configuration](https://parseplatform.github.io/docs/parse-server/guide/#push-notifications) in your parse server instance.
+
 ```php
 $data = array("alert" => "Hi!");
 


### PR DESCRIPTION
Adds clarification to the README that a working push configuration must be in place on your Parse Server instance in order to be able to use Push Notifications. Displays a link for information on setting up a working push configuration as well.