### PR TITLE
Adds switchable http clients with configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ require 'autoload.php';
 Initialization
 ---------------
 
-After including the required files from the SDK, you need to initalize the ParseClient using your Parse API keys:
+After including the required files from the SDK, you need to initialize the ParseClient using your Parse API keys:
 
 ```php
 ParseClient::initialize( $app_id, $rest_key, $master_key );
@@ -62,6 +62,43 @@ Parse server's default port is `1337` and the second parameter `parse` is the ro
 For example if your parse server's url is `http://example.com:1337/parse` then you can set the server url using the following snippet
 
 `ParseClient::setServerURL('https://example.com:1337','parse');`
+
+
+Http Clients
+------------
+
+This SDK has the ability to change the underlying http client at your convenience.
+The default is to use the curl http client if none is set, there is also a stream http client that can be used as well.
+
+Setting the http client can be done as follows:
+```php
+// set curl http client (default if none set)
+ParseClient::setHttpClient(new ParseCurlHttpClient());
+
+// set stream http client
+// ** requires 'allow_url_fopen' to be enabled in php.ini ** 
+ParseClient::setHttpClient(new ParseStreamHttpClient());
+```
+
+If you have a need for an additional http client you can request one by opening an issue or by submitting a PR.
+
+If you wish to build one yourself make sure your http client implements ```ParseHttpable``` for it be compatible with the SDK. Once you have a working http client that enhances the SDK feel free to submit it in a PR so we can look into adding it in.
+
+
+Alternate Certificate Authority File
+------------------------------------
+
+It is possible that your local setup may not be able to verify with peers over SSL/TLS. This may especially be the case if you do not have control over your local installation, such as for shared hosting.
+
+If this is the case you may need to specify a Certificate Authority bundle. You can download such a bundle from (http://curl.haxx.se/ca/cacert.pem)[http://curl.haxx.se/ca/cacert.pem] to use for this purpose. This one happens to be a Mozilla CA certificate store, you don't necessarily have to use this one but it's recommended.
+
+Once you have your bundle you can set it as follows:
+```php
+// ** Use an Absolute path for your file! **
+// holds one or more certificates to verify the peer with
+ParseClient::setCAFile(__DIR__ . '/certs/cacert.pem');
+```
+
 
 Usage
 -----

--- a/src/Parse/HttpClients/ParseCurl.php
+++ b/src/Parse/HttpClients/ParseCurl.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * ParseCurl - Wrapper for abstracted curl usage
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ */
+
+namespace Parse\HttpClients;
+
+
+use Parse\ParseException;
+
+/**
+ * Class ParseCurl
+ * @package Parse\HttpClients
+ */
+class ParseCurl
+{
+    /**
+     * Curl handle
+     * @var resource
+     */
+    private $curl;
+
+    /**
+     * Sets up a new curl instance internally if needed
+     */
+    public function init()
+    {
+        if($this->curl === null) {
+            $this->curl = curl_init();
+
+        }
+
+    }
+
+    /**
+     * Executes this curl request
+     *
+     * @return mixed
+     * @throws ParseException
+     */
+    public function exec()
+    {
+        if(!isset($this->curl)) {
+            throw new ParseException('You must call ParseCurl::init first');
+
+        }
+
+        return curl_exec($this->curl);
+    }
+
+    /**
+     * Sets a curl option
+     *
+     * @param int   $option Option to set
+     * @param mixed $value  Value to set for this option
+     * @throws ParseException
+     */
+    public function setOption($option, $value)
+    {
+        if(!isset($this->curl)) {
+            throw new ParseException('You must call ParseCurl::init first');
+
+        }
+
+        curl_setopt($this->curl, $option, $value);
+
+    }
+
+    /**
+     * Sets multiple curl options
+     *
+     * @param array $options    Array of options to set
+     * @throws ParseException
+     */
+    public function setOptionsArray($options)
+    {
+        if(!isset($this->curl)) {
+            throw new ParseException('You must call ParseCurl::init first');
+
+        }
+
+        curl_setopt_array($this->curl, $options);
+
+    }
+
+    /**
+     * Gets info for this curl handle
+     *
+     * @param int $info Constatnt for info to get
+     * @return mixed
+     * @throws ParseException
+     */
+    public function getInfo($info)
+    {
+        if(!isset($this->curl)) {
+            throw new ParseException('You must call ParseCurl::init first');
+
+        }
+
+        return curl_getinfo($this->curl, $info);
+
+    }
+
+    /**
+     * Gets the curl error message
+     *
+     * @return string
+     * @throws ParseException
+     */
+    public function getError()
+    {
+        if(!isset($this->curl)) {
+            throw new ParseException('You must call ParseCurl::init first');
+
+        }
+
+        return curl_error($this->curl);
+
+    }
+
+    /**
+     * Gets the curl error code
+     *
+     * @return int
+     * @throws ParseException
+     */
+    public function getErrorCode()
+    {
+        if(!isset($this->curl)) {
+            throw new ParseException('You must call ParseCurl::init first');
+
+        }
+
+        return curl_errno($this->curl);
+
+    }
+
+    /**
+     * Closed our curl handle and disposes of it
+     */
+    public function close()
+    {
+        if(!isset($this->curl)) {
+            throw new ParseException('You must call ParseCurl::init first');
+
+        }
+
+        // close our handle
+        curl_close($this->curl);
+
+        // unset our curl handle
+        $this->curl = null;
+
+    }
+
+}

--- a/src/Parse/HttpClients/ParseCurlHttpClient.php
+++ b/src/Parse/HttpClients/ParseCurlHttpClient.php
@@ -1,0 +1,384 @@
+<?php
+/**
+ * ParseCurlHttpClient - Curl http client
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ */
+
+namespace Parse\HttpClients;
+
+
+use Parse\ParseException;
+
+/**
+ * Class ParseCurlHttpClient
+ * @package Parse\HttpClients
+ */
+class ParseCurlHttpClient implements ParseHttpable
+{
+    /**
+     * Curl handle
+     * @var ParseCurl
+     */
+    private $parseCurl;
+
+    /**
+     * Request Headers
+     * @var array
+     */
+    private $headers = array();
+
+    /**
+     * Response headers
+     * @var array
+     */
+    private $responseHeaders = array();
+
+    /**
+     * Response code
+     * @var int
+     */
+    private $responseCode = 0;
+
+    /**
+     * Content type of our response
+     * @var string|null
+     */
+    private $responseContentType;
+
+    /**
+     * cURL error code
+     * @var int
+     */
+    private $curlErrorCode;
+
+    /**
+     * cURL error message
+     * @var string
+     */
+    private $curlErrorMessage;
+
+    /**
+     * @const Curl Version which is unaffected by the proxy header length error.
+     */
+    const CURL_PROXY_QUIRK_VER = 0x071E00;
+
+    /**
+     * @const "Connection Established" header text
+     */
+    const CONNECTION_ESTABLISHED = "HTTP/1.0 200 Connection established\r\n\r\n";
+
+    /**
+     * Response from our request
+     * @var string
+     */
+    private $response;
+
+
+    public function __construct()
+    {
+        if(!isset($this->parseCurl)) {
+            $this->parseCurl = new ParseCurl();
+
+        }
+    }
+
+    /**
+     * Adds a header to this request
+     *
+     * @param string $key       Header name
+     * @param string $value     Header value
+     */
+    public function addRequestHeader($key, $value)
+    {
+        $this->headers[$key]    = $value;
+
+    }
+
+    /**
+     * Builds and returns the coalesced request headers
+     *
+     * @return array
+     */
+    private function buildRequestHeaders()
+    {
+        // coalesce our header key/value pairs
+        $headers = [];
+        foreach($this->headers as $key => $value) {
+            $headers[] = $key.': '.$value;
+
+        }
+
+        return $headers;
+
+    }
+
+    /**
+     * Gets headers in the response
+     *
+     * @return array
+     */
+    public function getResponseHeaders()
+    {
+        return $this->responseHeaders;
+
+    }
+
+    /**
+     * Returns the status code of the response
+     *
+     * @return int
+     */
+    public function getResponseStatusCode()
+    {
+        return $this->responseCode;
+
+    }
+
+    /**
+     * Returns the content type of the response
+     *
+     * @return null|string
+     */
+    public function getResponseContentType()
+    {
+        return $this->responseContentType;
+
+    }
+
+    /**
+     * Sets up our cURL request in advance
+     */
+    public function setup()
+    {
+        // init parse curl
+        $this->parseCurl->init();
+
+        $this->parseCurl->setOptionsArray(array(
+            CURLOPT_RETURNTRANSFER  => 1,
+            CURLOPT_HEADER          => 1,
+            CURLOPT_FOLLOWLOCATION  => true,
+            CURLOPT_SSL_VERIFYPEER  => true,
+            CURLOPT_SSL_VERIFYHOST  => 2,
+        ));
+
+    }
+
+    /**
+     * Sends an HTTP request
+     *
+     * @param string $url       Url to send this request to
+     * @param string $method    Method to send this request via
+     * @param array $data       Data to send in this request
+     * @return string
+     * @throws ParseException
+     */
+    public function send($url, $method = 'GET', $data = array())
+    {
+
+        if($method == "GET" && !empty($data)) {
+            // handle get
+            $url .= '?'.http_build_query($data);
+
+        } else if($method == "POST") {
+            // handle post
+            $this->parseCurl->setOptionsArray(array(
+                CURLOPT_POST        => 1,
+                CURLOPT_POSTFIELDS  => $data
+            ));
+
+        } else if($method == "PUT") {
+            // handle put
+            $this->parseCurl->setOptionsArray(array(
+                CURLOPT_CUSTOMREQUEST   => $method,
+                CURLOPT_POSTFIELDS      => $data
+            ));
+
+        } else if($method == "DELETE") {
+            // handle delete
+            $this->parseCurl->setOption(CURLOPT_CUSTOMREQUEST, $method);
+
+        }
+
+        if(count($this->headers) > 0) {
+            // set our custom request headers
+            $this->parseCurl->setOption(CURLOPT_HTTPHEADER, $this->buildRequestHeaders());
+
+        }
+
+        // set url
+        $this->parseCurl->setOption(CURLOPT_URL, $url);
+
+        // perform our request and get our response
+        $this->response = $this->parseCurl->exec();
+
+        // get our response code
+        $this->responseCode = $this->parseCurl->getInfo(CURLINFO_HTTP_CODE);
+
+        // get our content type
+        $this->responseContentType = $this->parseCurl->getInfo(CURLINFO_CONTENT_TYPE);
+
+        // get any error code and message
+        $this->curlErrorMessage = $this->parseCurl->getError();
+        $this->curlErrorCode    = $this->parseCurl->getErrorCode();
+
+        // calculate size of our headers
+        $headerSize             = $this->getHeaderSize();
+
+        // get and set response headers
+        $headerContent          = trim(substr($this->response, 0, $headerSize));
+        $this->responseHeaders  = $this->getHeadersArray($headerContent);
+
+        // get our final response
+        $response               = trim(substr($this->response, $headerSize));
+
+        // close our handle
+        $this->parseCurl->close();
+
+        // flush our existing headers
+        $this->headers = array();
+
+        return $response;
+
+    }
+
+    /**
+     * Convert and return response headers as an array
+     * @param string $headerContent Raw headers to parse
+     *
+     * @return array
+     */
+    private function getHeadersArray($headerContent)
+    {
+        $headers = [];
+
+        // normalize our line breaks
+        $headerContent = str_replace("\r\n", "\n", $headerContent);
+
+        // Separate our header sets, particularly if we followed a 301 redirect
+        $headersSet = explode("\n\n", $headerContent);
+
+        // Get the last set of headers, ignoring all others
+        $rawHeaders = array_pop($headersSet);
+
+        // sepearate our header components
+        $headerComponents = explode("\n", $rawHeaders);
+
+        foreach($headerComponents as $component) {
+            if (strpos($component, ': ') === false) {
+                // set our http_code
+                $headers['http_code'] = $component;
+
+
+            } else {
+                // set this header key/value pair
+                list($key, $value) = explode(': ', $component);
+                $headers[$key]      = $value;
+
+            }
+        }
+
+        // return our completed headers
+        return $headers;
+
+    }
+
+
+    /**
+     * Sets the connection timeout
+     *
+     * @param int $timeout  Timeout to set
+     */
+    public function setConnectionTimeout($timeout)
+    {
+        $this->parseCurl->setOption(CURLOPT_CONNECTTIMEOUT, $timeout);
+
+    }
+
+    /**
+     * Sets the request timeout
+     *
+     * @param int $timeout  Sets the timeout for the request
+     */
+    public function setTimeout($timeout)
+    {
+        $this->parseCurl->setOption(CURLOPT_TIMEOUT, $timeout);
+
+    }
+
+    /**
+     * Sets the CA file to validate requests with
+     *
+     * @param string $caFile    CA file to set
+     */
+    public function setCAFile($caFile)
+    {
+        // name of a file holding one or more certificates to verify the peer with
+        $this->parseCurl->setOption(CURLOPT_CAINFO, $caFile);
+
+    }
+
+    /**
+     * Gets the error code
+     *
+     * @return int
+     */
+    public function getErrorCode()
+    {
+        return $this->curlErrorCode;
+
+    }
+
+    /**
+     * Gets the error message
+     *
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->curlErrorMessage;
+
+    }
+
+    /**
+     * Return proper header size
+     *
+     * @return integer
+     */
+    private function getHeaderSize()
+    {
+        $headerSize = $this->parseCurl->getInfo(CURLINFO_HEADER_SIZE);
+
+        // This corrects a Curl bug where header size does not account
+        // for additional Proxy headers.
+        if ( $this->needsCurlProxyFix() ) {
+
+            // Additional way to calculate the request body size.
+            if (preg_match('/Content-Length: (\d+)/', $this->response, $match)) {
+                $headerSize = mb_strlen($this->response) - $match[1];
+
+            } elseif (stripos($this->response, self::CONNECTION_ESTABLISHED) !== false) {
+                $headerSize += mb_strlen(self::CONNECTION_ESTABLISHED);
+
+            }
+        }
+        return $headerSize;
+
+    }
+
+    /**
+     * Detect versions of Curl which report incorrect header lengths when
+     * using Proxies.
+     *
+     * @return boolean
+     */
+    private function needsCurlProxyFix()
+    {
+        $versionDat = curl_version();
+        $version    = $versionDat['version_number'];
+
+        return $version < self::CURL_PROXY_QUIRK_VER;
+
+    }
+
+}

--- a/src/Parse/HttpClients/ParseHttpable.php
+++ b/src/Parse/HttpClients/ParseHttpable.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * ParseHttpable - Interface for an HTTPable client
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ */
+
+namespace Parse\HttpClients;
+
+
+interface ParseHttpable
+{
+    /**
+     * Adds a header to this request
+     *
+     * @param string $key       Header name
+     * @param string $value     Header value
+     */
+    public function addRequestHeader($key, $value);
+
+    /**
+     * Gets headers in the response
+     *
+     * @return array
+     */
+    public function getResponseHeaders();
+
+    /**
+     * Returns the status code of the response
+     *
+     * @return int
+     */
+    public function getResponseStatusCode();
+
+    /**
+     * Returns the content type of the response
+     *
+     * @return null|string
+     */
+    public function getResponseContentType();
+
+    /**
+     * Sets the connection timeout
+     *
+     * @param int $timeout  Timeout to set
+     */
+    public function setConnectionTimeout($timeout);
+
+    /**
+     * Sets the request timeout
+     *
+     * @param int $timeout  Sets the timeout for the request
+     */
+    public function setTimeout($timeout);
+
+    /**
+     * Sets the CA file to validate requests with
+     *
+     * @param string $caFile    CA file to set
+     */
+    public function setCAFile($caFile);
+
+    /**
+     * Gets the error code
+     *
+     * @return int
+     */
+    public function getErrorCode();
+
+    /**
+     * Gets the error message
+     *
+     * @return string
+     */
+    public function getErrorMessage();
+
+    /**
+     * Sets up our client before we make a request
+     */
+    public function setup();
+
+    /**
+     * Sends an HTTP request
+     *
+     * @param string $url       Url to send this request to
+     * @param string $method    Method to send this request via
+     * @param array $data       Data to send in this request
+     * @return string
+     */
+    public function send($url, $method = 'GET', $data = array());
+
+}

--- a/src/Parse/HttpClients/ParseStream.php
+++ b/src/Parse/HttpClients/ParseStream.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * ParseStream - Wrapper for abstracted stream usage
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ */
+
+namespace Parse\HttpClients;
+
+/**
+ * Class ParseStream
+ * @package Parse\HttpClients
+ */
+class ParseStream
+{
+    /**
+     *
+     * @var resource
+     */
+    private $stream;
+
+    /**
+     * Response headers
+     * @var array|null
+     */
+    private $responseHeaders;
+
+    /**
+     * Error message
+     * @var string
+     */
+    private $errorMessage;
+
+    /**
+     * Error code
+     * @var int
+     */
+    private $errorCode;
+
+    /**
+     * Create a stream context
+     *
+     * @param array $options  Options to pass to our context
+     */
+    public function createContext($options)
+    {
+        $this->stream = stream_context_create($options);
+
+    }
+
+    /**
+     * Gets the contents from the given url
+     *
+     * @param string $url   Url to get contents of
+     * @return string
+     */
+    public function get($url)
+    {
+        try {
+            // get our response
+            $response = file_get_contents($url, false, $this->stream);
+
+        } catch(\Exception $e) {
+            // set our error message/code and return false
+            $this->errorMessage = $e->getMessage();
+            $this->errorCode    = $e->getCode();
+            return false;
+
+        }
+
+        // set response headers
+        $this->responseHeaders = $http_response_header;
+
+        return $response;
+
+    }
+
+    /**
+     * Returns the response headers for the last request
+     *
+     * @return array
+     */
+    public function getResponseHeaders()
+    {
+        return $this->responseHeaders;
+
+    }
+
+    /**
+     * Gets the current error message
+     *
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+
+    }
+
+    /**
+     * Gest the current error code
+     *
+     * @return int
+     */
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+
+    }
+
+}

--- a/src/Parse/HttpClients/ParseStreamHttpClient.php
+++ b/src/Parse/HttpClients/ParseStreamHttpClient.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * ParseStreamHttpClient - Stream http client
+ *
+ * @author Ben Friedman <ben@axolsoft.com>
+ */
+
+namespace Parse\HttpClients;
+
+
+use Parse\ParseException;
+
+class ParseStreamHttpClient implements ParseHttpable
+{
+    /**
+     * Stream handle
+     * @var ParseStream
+     */
+    private $parseStream;
+
+    /**
+     * Request Headers
+     * @var array
+     */
+    private $headers = array();
+
+    /**
+     * Response headers
+     * @var array
+     */
+    private $responseHeaders = array();
+
+    /**
+     * Response code
+     * @var int
+     */
+    private $responseCode = 0;
+
+    /**
+     * Content type of our response
+     * @var string|null
+     */
+    private $responseContentType;
+
+    /**
+     * Stream error code
+     * @var int
+     */
+    private $streamErrorCode;
+
+    /**
+     * Stream error message
+     * @var string
+     */
+    private $streamErrorMessage;
+
+    /**
+     * Options to pass to our stream
+     * @var array
+     */
+    private $options = array();
+
+    /**
+     * Optional CA file to verify our peers with
+     * @var string
+     */
+    private $caFile;
+
+    /**
+     * Response from our request
+     * @var string
+     */
+    private $response;
+
+    public function __construct()
+    {
+        if(!isset($this->parseStream)) {
+            $this->parseStream = new ParseStream();
+
+        }
+    }
+
+
+
+    /**
+     * Adds a header to this request
+     *
+     * @param string $key       Header name
+     * @param string $value     Header value
+     */
+    public function addRequestHeader($key, $value)
+    {
+        $this->headers[$key]    = $value;
+
+    }
+
+    /**
+     * Gets headers in the response
+     *
+     * @return array
+     */
+    public function getResponseHeaders()
+    {
+        return $this->responseHeaders;
+
+    }
+
+    /**
+     * Returns the status code of the response
+     *
+     * @return int
+     */
+    public function getResponseStatusCode()
+    {
+        return $this->responseCode;
+
+    }
+
+    /**
+     * Returns the content type of the response
+     *
+     * @return null|string
+     */
+    public function getResponseContentType()
+    {
+        return $this->responseContentType;
+
+    }
+
+    /**
+     * Builds and returns the coalesced request headers
+     *
+     * @return array
+     */
+    private function buildRequestHeaders()
+    {
+        // coalesce our header key/value pairs
+        $headers = [];
+        foreach($this->headers as $key => $value) {
+            if($key == 'Expect' && $value == '') {
+                // drop this pair
+                continue;
+
+            }
+
+            // add this header key/value pair
+            $headers[] = $key.': '.$value;
+
+        }
+
+        return implode("\r\n", $headers);
+
+    }
+
+    public function setup()
+    {
+        // setup ssl options
+        $this->options['ssl'] = array(
+            'verify_peer'       => true,
+            'verify_peer_name'  => true,
+            'allow_self_signed' => true, // All root certificates are self-signed
+            'follow_location'   => 1
+        );
+
+    }
+
+    public function send($url, $method = 'GET', $data = array())
+    {
+
+        // verify this url
+        if(preg_match('/\s/', trim($url))) {
+            throw new ParseException('Url may not contain spaces for stream client: '.$url);
+
+        }
+
+        if(isset($this->caFile)) {
+            // set CA file as well
+            $this->options['ssl']['cafile'] = $this->caFile;
+
+        }
+
+        // add additional options for this request
+        $this->options['http'] = array(
+            'method'        => $method,
+            'ignore_errors' => true
+        );
+
+        if(isset($this->timeout)) {
+            $this->options['http']['timeout']   = $this->timeout;
+
+        }
+
+        if(isset($data) && $data != "{}") {
+            if ($method == "GET") {
+                // handle GET
+                $query = http_build_query($data, null, '&');
+                $this->options['http']['content'] = $query;
+                $this->addRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+
+            } else if ($method == "POST") {
+                // handle POST
+                $this->options['http']['content'] = $data;
+
+            } else if ($method == "PUT") {
+                // handle PUT
+                $this->options['http']['content'] = $data;
+
+            }
+
+        }
+
+        // set headers
+        $this->options['http']['header'] = $this->buildRequestHeaders();
+
+        // create a stream context
+        $this->parseStream->createContext($this->options);
+
+        // send our request
+        $response = $this->parseStream->get($url);
+
+        // get our response headers
+        $rawHeaders = $this->parseStream->getResponseHeaders();
+
+        if ($response === false || !$rawHeaders) {
+            // set an error and code
+            $this->streamErrorMessage   = $this->parseStream->getErrorMessage();
+            $this->streamErrorCode      = $this->parseStream->getErrorCode();
+
+        } else {
+
+            // set our response headers
+            $this->responseHeaders = self::formatHeaders($rawHeaders);
+
+            // get and set content type, if present
+            if(isset($this->responseHeaders['Content-Type'])) {
+                $this->responseContentType = $this->responseHeaders['Content-Type'];
+
+            }
+
+            // set our http status code
+            $this->responseCode = self::getStatusCodeFromHeader($this->responseHeaders['http_code']);
+
+        }
+
+        // clear options
+        $this->options = array();
+
+        // flush our existing headers
+        $this->headers = array();
+
+        return $response;
+
+    }
+
+    /**
+     * Converts unformatted headers to an array of headers
+     *
+     * @param array $rawHeaders
+     *
+     * @return array
+     */
+    public static function formatHeaders(array $rawHeaders)
+    {
+        $headers = array();
+
+        foreach ($rawHeaders as $line) {
+            if (strpos($line, ':') === false) {
+                // set our http status code
+                $headers['http_code'] = $line;
+
+            } else {
+                // set this header entry
+                list ($key, $value) = explode(': ', $line);
+                $headers[$key]      = $value;
+
+            }
+        }
+
+        return $headers;
+
+    }
+    /**
+     * Extracts the Http status code from the given header
+     *
+     * @param string $header
+     *
+     * @return int
+     */
+    public static function getStatusCodeFromHeader($header)
+    {
+        preg_match('{HTTP/\d\.\d\s+(\d+)\s+.*}', $header, $match);
+        return (int) $match[1];
+
+    }
+
+    /**
+     * Gets the error code
+     *
+     * @return int
+     */
+    public function getErrorCode()
+    {
+        return $this->streamErrorCode;
+
+    }
+
+    /**
+     * Gets the error message
+     *
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->streamErrorMessage;
+
+    }
+
+    public function setConnectionTimeout($timeout)
+    {
+        // do nothing
+    }
+
+    /**
+     * Sets the CA file to validate requests with
+     *
+     * @param string $caFile    CA file to set
+     */
+    public function setCAFile($caFile)
+    {
+        $this->caFile = $caFile;
+
+    }
+
+    /**
+     * Sets the request timeout
+     *
+     * @param int $timeout  Sets the timeout for the request
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
+
+    }
+
+
+}

--- a/tests/Parse/Helper.php
+++ b/tests/Parse/Helper.php
@@ -2,7 +2,10 @@
 
 namespace Parse\Test;
 
+use Parse\HttpClients\ParseCurlHttpClient;
+use Parse\HttpClients\ParseStreamHttpClient;
 use Parse\ParseClient;
+use Parse\ParseException;
 use Parse\ParseObject;
 use Parse\ParseQuery;
 
@@ -47,6 +50,29 @@ class Helper
             self::$accountKey
         );
         self::setServerURL();
+        self::setHttpClient();
+
+    }
+
+    public static function setHttpClient()
+    {
+        //
+        // Set a curl http client to run primary tests under
+        // may be:
+        //
+        // ParseCurlHttpClient
+        // ParseStreamHttpClient
+        //
+
+        if(function_exists('curl_init')) {
+            // cURL client
+            ParseClient::setHttpClient(new ParseCurlHttpClient());
+
+        } else {
+            // stream client
+            ParseClient::setHttpClient(new ParseStreamHttpClient());
+        }
+
     }
 
     public static function setServerURL()

--- a/tests/Parse/IncrementTest.php
+++ b/tests/Parse/IncrementTest.php
@@ -18,6 +18,9 @@ class IncrementTest extends \PHPUnit_Framework_TestCase
         Helper::tearDown();
     }
 
+    /**
+     * @group fresh-increment
+     */
     public function testIncrementOnFreshObject()
     {
         $obj = ParseObject::create('TestObject');
@@ -184,6 +187,9 @@ class IncrementTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @group increment-empty
+     */
     public function testIncrementEmptyField()
     {
         $obj = ParseObject::create('TestObject');
@@ -205,6 +211,9 @@ class IncrementTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @group empty-field-type-conflict
+     */
     public function testIncrementEmptyFieldAndTypeConflict()
     {
         $obj = ParseObject::create('TestObject');

--- a/tests/Parse/ParseACLTest.php
+++ b/tests/Parse/ParseACLTest.php
@@ -34,6 +34,9 @@ class ParseACLTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    /**
+     * @group acl-one-user
+     */
     public function testACLAnObjectOwnedByOneUser()
     {
         $user = new ParseUser();

--- a/tests/Parse/ParseCurlHttpClientTest.php
+++ b/tests/Parse/ParseCurlHttpClientTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 2/20/17
+ * Time: 1:08 PM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\HttpClients\ParseCurlHttpClient;
+
+class ParseCurlHttpClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResponseStatusCode()
+    {
+        $client = new ParseCurlHttpClient();
+        $client->setup();
+        $client->send("http://example.com");
+
+        $this->assertEquals(200, $client->getResponseStatusCode());
+
+    }
+}

--- a/tests/Parse/ParseCurlTest.php
+++ b/tests/Parse/ParseCurlTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 2/20/17
+ * Time: 1:05 PM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\HttpClients\ParseCurl;
+use Parse\ParseException;
+
+class ParseCurlTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBadExec()
+    {
+        $this->setExpectedException(ParseException::class,
+            'You must call ParseCurl::init first');
+
+        $parseCurl = new ParseCurl();
+        $parseCurl->exec();
+
+    }
+
+    public function testBadSetOption()
+    {
+        $this->setExpectedException(ParseException::class,
+            'You must call ParseCurl::init first');
+
+        $parseCurl = new ParseCurl();
+        $parseCurl->setOption(1, 1);
+
+    }
+
+    public function testBadSetOptionsArray()
+    {
+        $this->setExpectedException(ParseException::class,
+            'You must call ParseCurl::init first');
+
+        $parseCurl = new ParseCurl();
+        $parseCurl->setOptionsArray([]);
+
+    }
+
+    public function testBadGetInfo()
+    {
+        $this->setExpectedException(ParseException::class,
+            'You must call ParseCurl::init first');
+
+        $parseCurl = new ParseCurl();
+        $parseCurl->getInfo(1);
+
+    }
+
+    public function testBadGetError()
+    {
+        $this->setExpectedException(ParseException::class,
+            'You must call ParseCurl::init first');
+
+        $parseCurl = new ParseCurl();
+        $parseCurl->getError();
+
+    }
+
+    public function testBadErrorCode()
+    {
+        $this->setExpectedException(ParseException::class,
+            'You must call ParseCurl::init first');
+
+        $parseCurl = new ParseCurl();
+        $parseCurl->getErrorCode();
+
+    }
+
+    public function testBadClose()
+    {
+        $this->setExpectedException(ParseException::class,
+            'You must call ParseCurl::init first');
+
+        $parseCurl = new ParseCurl();
+        $parseCurl->close();
+
+    }
+}

--- a/tests/Parse/ParseFileTest.php
+++ b/tests/Parse/ParseFileTest.php
@@ -40,6 +40,9 @@ class ParseFileTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @group file-upload-test
+     */
     public function testParseFileUpload()
     {
         $file = ParseFile::createFromData('Fosco', 'test.txt');

--- a/tests/Parse/ParseRoleTest.php
+++ b/tests/Parse/ParseRoleTest.php
@@ -97,6 +97,9 @@ class ParseRoleTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    /**
+     * @group explicit-role-acl
+     */
     public function testExplicitRoleACL()
     {
         $eden = $this->createEden();

--- a/tests/Parse/ParseSchemaTest.php
+++ b/tests/Parse/ParseSchemaTest.php
@@ -10,6 +10,9 @@
  */
 namespace Parse\Test;
 
+use Parse\HttpClients\ParseCurlHttpClient;
+use Parse\HttpClients\ParseStreamHttpClient;
+use Parse\ParseClient;
 use Parse\ParseException;
 use Parse\ParseSchema;
 use Parse\ParseUser;
@@ -35,6 +38,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
     {
         self::$schema = new ParseSchema('SchemaTest');
         Helper::clearClass('_User');
+        Helper::setHttpClient();
 
     }
 
@@ -133,8 +137,10 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         $schema_2->delete();
     }
 
-    public function testUpdateSchema()
+    public function testUpdateSchemaStream()
     {
+        ParseClient::setHttpClient(new ParseStreamHttpClient());
+
         // create
         $schema = self::$schema;
         $schema->addString('name');
@@ -153,6 +159,32 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertNotNull($result['fields']['quantity']);
         $this->assertNotNull($result['fields']['status']);
+
+    }
+
+    public function testUpdateSchemaCurl()
+    {
+        ParseClient::setHttpClient(new ParseCurlHttpClient());
+
+        // create
+        $schema = self::$schema;
+        $schema->addString('name');
+        $schema->save();
+        // update
+        $schema->deleteField('name');
+        $schema->addNumber('quantity');
+        $schema->addField('status', 'Boolean');
+        $schema->update();
+        // get
+        $getSchema = new ParseSchema('SchemaTest');
+        $result = $getSchema->get();
+
+        if (isset($result['fields']['name'])) {
+            $this->fail('Field not deleted in update action');
+        }
+        $this->assertNotNull($result['fields']['quantity']);
+        $this->assertNotNull($result['fields']['status']);
+
     }
 
     public function testUpdateWrongFieldType()
@@ -302,8 +334,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSchemaGet()
     {
-        $this->setExpectedException(ParseException::class,
-            'Empty reply from server');
+        $this->setExpectedException(ParseException::class);
 
         $user = new ParseUser();
         $user->setUsername('schema-user');
@@ -320,8 +351,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSchemaSave()
     {
-        $this->setExpectedException(ParseException::class,
-            'Empty reply from server');
+        $this->setExpectedException(ParseException::class);
 
         $user = new ParseUser();
         $user->setUsername('schema-user');
@@ -338,8 +368,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSchemaUpdate()
     {
-        $this->setExpectedException(ParseException::class,
-            'Empty reply from server');
+        $this->setExpectedException(ParseException::class);
 
         $user = new ParseUser();
         $user->setUsername('schema-user');
@@ -356,8 +385,7 @@ class ParseSchemaTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadSchemaDelete()
     {
-        $this->setExpectedException(ParseException::class,
-            'Empty reply from server');
+        $this->setExpectedException(ParseException::class);
 
         $user = new ParseUser();
         $user->setUsername('schema-user');

--- a/tests/Parse/ParseStreamHttpClientTest.php
+++ b/tests/Parse/ParseStreamHttpClientTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Bfriedman
+ * Date: 2/20/17
+ * Time: 1:11 PM
+ */
+
+namespace Parse\Test;
+
+
+use Parse\HttpClients\ParseStreamHttpClient;
+use Parse\ParseClient;
+use Parse\ParseException;
+
+class ParseStreamHttpClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetResponse()
+    {
+        $client = new ParseStreamHttpClient();
+        $client->send('http://example.com');
+
+        // get response code
+        $this->assertEquals(200, $client->getResponseStatusCode());
+
+        // get response headers
+        $headers = $client->getResponseHeaders();
+
+        $this->assertEquals('HTTP/1.0 200 OK', $headers['http_code']);
+
+    }
+
+    public function testInvalidUrl()
+    {
+        $url = 'http://example.com/lots of spaces here';
+
+        $this->setExpectedException(ParseException::class,
+            'Url may not contain spaces for stream client: '
+            .$url);
+
+        $client = new ParseStreamHttpClient();
+        $client->send($url);
+    }
+}


### PR DESCRIPTION
This is for #59, dating back to late 2014. It addresses the issue that not everyone can use the same transport layer to power the sdk. For example curl may not be available (or discouraged) over an alternative implementation. One such case would be the [http api](https://codex.wordpress.org/HTTP_API) on wordpress. In a general sense environments where the user does not have control over their php installation should be given a variety of http clients to choose from.

This introduces pluggable transport layers, where the underlying http client may be changed using either one of the provided clients or even a custom user implementation. This PR provides two such clients, ```ParseCurlHttpClient``` and ```ParseStreamHttpClient```, where the former is the default. 

Setting a client can be achieved via the newly added ```ParseClient::setHttpClient``` as follows:
```php
// set a stream client instead of the default cURL client
ParseClient::setHttpClient(new ParseStreamHttpClient());
```

This is closely related to facebook's implementation in their [ php graph sdk](https://github.com/facebook/php-graph-sdk/blob/4.0-dev/src/Facebook/FacebookRequest.php). To that end there is a ```ParseHttpable``` interface which can be implemented to provide additional transport layers. Http clients can implement this to provide additional choices, such as in the case of wordpress (but not included in this PR).

Additionally in some shared hosting implementations it may be required to provide an alternative CA bundle, which if not present could lead to an inability to verify peer's certificates. To account for this I have added ```ParseClient::setCAFile``` and updated the README with an appropriate usage (including a brief explanation of where to obtain a bundle). I have seen some instances of individuals attempting to disable peer verification to bypass such issues. This should incentivize trying to set an alternative CA bundle instead over disabling verification altogether. 

The README and tests have been updated to document and cover this newly added functionality.