### PR TITLE
Fixes save issue with bi-directional relations via pointers

### DIFF
--- a/src/Parse/ParseObject.php
+++ b/src/Parse/ParseObject.php
@@ -279,7 +279,7 @@ class ParseObject implements Encodable
             $this->estimatedData,
             function ($object) use (&$result) {
                 if ($object instanceof ParseObject) {
-                    if ($object->isDirty()) {
+                    if ($object->_isDirty(false)) {
                         $result = true;
                     }
                 }

--- a/tests/Parse/ParseObjectTest.php
+++ b/tests/Parse/ParseObjectTest.php
@@ -1149,6 +1149,9 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    /**
+     * @group dirty-children
+     */
     public function testDirtyChildren()
     {
         $obj = new ParseObject('TestClass');
@@ -1161,10 +1164,51 @@ class ParseObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($obj->isDirty());
 
         $obj->set('innerObject', $obj2);
+        $this->assertTrue($obj->isDirty());
+
+        $this->assertTrue($obj2->isDirty());
+
+        $obj->save();
+        $this->assertFalse($obj->isDirty());
+        $this->assertFalse($obj2->isDirty());
+
+
+        // update the child again
+        $obj2->set('key2', 'an unsaved value');
+        $this->assertTrue($obj->isDirty());
+        $obj->save();
+
+
+        // test setting a child in child
+        $obj3 = new ParseObject('TestClass');
+        $obj3->set('key2', 'child of child');
+        $obj2->set('innerObject', $obj3);
 
         $this->assertTrue($obj->isDirty());
 
+        $obj2->save();
+        $this->assertFalse($obj->isDirty());
+
+        $obj3->set('key2', 'an unsaved value 2');
+        $this->assertTrue($obj->isDirty());
+
+
+        // test setting a child in child in child!
+        $obj4 = new ParseObject('TestClass');
+        $obj4->set('key2', 'child of child of child!');
+        $obj3->set('innerObject', $obj4);
+
+        $this->assertTrue($obj->isDirty());
+
+        $obj3->save();
+        $this->assertFalse($obj->isDirty());
+
+        $obj4->set('key2', 'an unsaved value 3');
+        $this->assertTrue($obj->isDirty());
+
         $obj->destroy();
+        $obj2->destroy();
+        $obj3->destroy();
 
     }
 

--- a/tests/Parse/ParseRelationTest.php
+++ b/tests/Parse/ParseRelationTest.php
@@ -188,4 +188,35 @@ class ParseRelationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('child3', $children[0]->get('name'));
 
     }
+
+    /**
+     * Verifies bi directional relations can be saved when an array of pointers is used and is in dirty state
+     * @author zeliard91
+     * @group bidir-test
+     */
+    public function testBiDirectionalRelations()
+    {
+        Helper::clearClass('BiParent');
+        Helper::clearClass('BiChild');
+
+        $parent = new ParseObject('BiParent');
+
+        $child = new ParseObject('BiChild');
+        $child->set('name', 'Child');
+        $child->set('parent', $parent);
+
+        $child->save();
+        $parent->save();
+
+        $child2 = new ParseObject('BiChild');
+        $child2->set('name', 'Child 2');
+        $child2->set('parent', $parent);
+
+        $parent->setArray('children', [$child, $child2]);
+
+        $child2->save();
+        $parent->save();
+
+    }
+
 }


### PR DESCRIPTION
This is a patch for #293, modifying ```ParseObject::hasDirtyChildren``` to not crash on circular references when saving objects.

Originally ```hasDirtyChildren``` would continually reevaluate child objects by calling ```$object->isDirty()```, which could inadvertently cause an infinite between two objects both referencing each other via pointers. In order for the parent to be checked for dirtiness the child would as well, and the child in turn would require that the parent be checked, which in turn would loop the process again until a maximum function nesting depth was reached.

Modifying ```ParseObject::hasDirtyChildren``` to check a child object's dirtiness by calling ```$object->_isDirty(false)``` performs the same check while avoiding such a loop, allowing us to evaluate child objects (and even child objects in child objects or further) without accidentally reevaluating from the parent down again. ```ParseObject::findUnsavedChildren``` uses the same technique to ensure it doesn't run into an infinite loop while evaluating child objects.

This passes all tests and incorporates additional tests to cover the modified functionality and to watch against any similar issues involving circular references.